### PR TITLE
Fix error messages and typos

### DIFF
--- a/inst/buttord.m
+++ b/inst/buttord.m
@@ -53,7 +53,7 @@
 ## Theory: For Low pass filters, |H(W)|^2 = 1/[1+(W/Wc)^(2N)] = 10^(-R/10).
 ## With some algebra, you can solve simultaneously for Wc and N given
 ## Ws,Rs and Wp,Rp. Rounding N to the next greater integer, one can recalculate
-## the allowable range for Wc (filter caracteristic touching the pass band edge
+## the allowable range for Wc (filter characteristic touching the pass band edge
 ## or the stop band edge).
 ##
 ## For other types of filter, before making the above calculation, the
@@ -67,7 +67,7 @@ function [n, Wc_p, Wc_s] = buttord (Wp, Ws, Rp, Rs, opt)
   if (nargin < 4 || nargin > 5)
     print_usage ();
   elseif (nargin == 5 && ! strcmp (opt, "s"))
-    error ("ellipord: OPT must be the string \"s\"");
+    error ("buttord: OPT must be the string \"s\"");
   endif
 
   if (nargin == 5 && strcmp (opt, "s"))

--- a/inst/cheb1ord.m
+++ b/inst/cheb1ord.m
@@ -58,7 +58,7 @@ function [n, Wc_p, Wc_s] = cheb1ord (Wp, Ws, Rp, Rs, opt)
   if (nargin < 4 || nargin > 5)
     print_usage ();
   elseif (nargin == 5 && ! strcmp (opt, "s"))
-    error ("ellipord: OPT must be the string \"s\"");
+    error ("cheb1ord: OPT must be the string \"s\"");
   endif
 
   if (nargin == 5 && strcmp (opt, "s"))
@@ -141,7 +141,7 @@ function [n, Wc_p, Wc_s] = cheb1ord (Wp, Ws, Rp, Rs, opt)
   pass_atten = 10 ^ (abs (Rp) / 10);
   n = ceil (acosh (sqrt ((stop_atten - 1) / (pass_atten - 1))) / acosh (Wa));
 
-  ## compute stopband frequency limits to make the the filter characteristic
+  ## compute stopband frequency limits to make the filter characteristic
   ## touch either at least one stop band corner or one pass band corner.
 
   epsilon = 1 / sqrt (10 ^ (.1 * abs (Rs)) - 1);

--- a/inst/cheb2ord.m
+++ b/inst/cheb2ord.m
@@ -57,7 +57,7 @@ function [n, Wc_p, Wc_s] = cheb2ord (Wp, Ws, Rp, Rs, opt)
   if (nargin < 4 || nargin > 5)
     print_usage ();
   elseif (nargin == 5 && ! strcmp (opt, "s"))
-    error ("ellipord: OPT must be the string \"s\"");
+    error ("cheb2ord: OPT must be the string \"s\"");
   endif
 
   if (nargin == 5 && strcmp (opt, "s"))
@@ -140,7 +140,7 @@ function [n, Wc_p, Wc_s] = cheb2ord (Wp, Ws, Rp, Rs, opt)
   pass_atten = 10 ^ (abs (Rp) / 10);
   n = ceil (acosh (sqrt ((stop_atten - 1) / (pass_atten - 1))) / acosh (Wa));
 
-  ## compute stopband frequency limits to make the the filter characteristic
+  ## compute stopband frequency limits to make the filter characteristic
   ## touch either at least one stop band corner or one pass band corner.
 
   epsilon = 1 / sqrt (10 ^ (.1 * abs (Rs)) - 1);


### PR DESCRIPTION
Corrected error message function names in buttord, cheb1ord, and cheb2ord to reference the correct function. Fixed typos in comments for clarity.