### PR TITLE
Fix repeated word 'the' in documentation comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To install, run the octave package manager:
    
    `pkg install signal-XXXXXXX.tar.gz`
    
-   Where XXXXXXX is the version of the the downloaded tarball.
+   Where XXXXXXX is the version of the downloaded tarball.
 
 Usage:
 ======

--- a/inst/dct.m
+++ b/inst/dct.m
@@ -20,7 +20,7 @@
 ## Compute the discrete cosine transform of @var{x}.  If @var{n} is given,
 ## then @var{x} is padded or trimmed to length @var{n} before computing the
 ## transform.  If @var{x} is a matrix, compute the transform along the columns
-## of the the matrix.  The transform is faster if @var{x} is real-valued and
+## of the matrix.  The transform is faster if @var{x} is real-valued and
 ## has even length.
 ##
 ## The discrete cosine transform @var{x} can be defined as follows:

--- a/inst/findpeaks.m
+++ b/inst/findpeaks.m
@@ -74,7 +74,7 @@
 ## @verbatim
 ## a * width^2 = 1
 ## @end verbatim
-## where a is the the concavity of the parabola.
+## where a is the concavity of the parabola.
 ## Default value @code{eps}.
 ##
 ## @item "MaxPeakWidth"

--- a/inst/idct.m
+++ b/inst/idct.m
@@ -20,7 +20,7 @@
 ## Compute the inverse discrete cosine transform of @var{x}.  If @var{n} is
 ## given, then @var{x} is padded or trimmed to length @var{n} before computing
 ## the transform.  If @var{x} is a matrix, compute the transform along the
-## columns of the the matrix.  The transform is faster if @var{x} is
+## columns of the matrix.  The transform is faster if @var{x} is
 ## real-valued and even length.
 ##
 ## The inverse discrete cosine transform @var{x} can be defined as follows:

--- a/inst/idst.m
+++ b/inst/idst.m
@@ -7,7 +7,7 @@
 ## Computes the inverse type I discrete sine transform of @var{y}.  If @var{n} is
 ## given, then @var{y} is padded or trimmed to length @var{n} before computing
 ## the transform.  If @var{y} is a matrix, compute the transform along the
-## columns of the the matrix.
+## columns of the matrix.
 ## @seealso{dst}
 ## @end deftypefn
 

--- a/inst/impz.m
+++ b/inst/impz.m
@@ -22,7 +22,7 @@
 ## @deftypefnx {Function File} {} impz (@dots{})
 ##
 ## Generate impulse-response characteristics of the filter. The filter
-## coefficients correspond to the the z-plane rational function with
+## coefficients correspond to the z-plane rational function with
 ## numerator b and denominator a.  If a is not specified, it defaults to
 ## 1. If n is not specified, or specified as [], it will be chosen such
 ## that the signal has a chance to die down to -120dB, or to not explode

--- a/inst/pulstran.m
+++ b/inst/pulstran.m
@@ -36,8 +36,8 @@
 ##
 ## If instead of a function name you supply a pulse shape sampled at
 ## frequency Fs (default 1 Hz),  an interpolated version of the pulse
-## is added at each delay d.  The interpolation stays within the the
-## time range of the delayed pulse.  The interpolation method defaults
+## is added at each delay d.  The interpolation stays within the time
+## range of the delayed pulse.  The interpolation method defaults
 ## to linear, but it can be any interpolation method accepted by the
 ## function interp1.
 ##

--- a/inst/residued.m
+++ b/inst/residued.m
@@ -68,7 +68,7 @@ function [r, p, f, m] = residued(b, a, toler)
   ## and M is the order of F(z) = length(f)-1 = nb-na.
   ##
   ## Note, in particular, that the impulse-response of the parallel
-  ## (complex) one-pole filter bank starts AFTER that of the the FIR part.
+  ## (complex) one-pole filter bank starts AFTER that of the FIR part.
   ## In the result returned by RESIDUEZ, R(z) is not divided by z^M,
   ## so its impulse response starts at time 0 in parallel with f(n).
   ##

--- a/inst/residuez.m
+++ b/inst/residuez.m
@@ -60,7 +60,7 @@ function [r, p, f, m] = residuez(B, A, tol)
   ##
   ## where R(z) is the parallel one-pole filter bank defined above.
   ## Note, in particular, that the impulse-response of the one-pole
-  ## filter bank is in parallel with that of the the FIR part.  This can
+  ## filter bank is in parallel with that of the FIR part.  This can
   ## be wasteful when matching the initial impulse response is important,
   ## since F(z) can already match the first N terms of the impulse
   ## response. To obtain a decomposition in which the impulse response of


### PR DESCRIPTION
The last time I submitted changes, I noticed that some files had duplicated `the the`. So in this commit, I searched the code and removed the duplicates.