### PR TITLE
Improve input validation in downsample.m

### DIFF
--- a/inst/downsample.m
+++ b/inst/downsample.m
@@ -3,25 +3,35 @@
 
 ## -*- texinfo -*-
 ## @deftypefn  {Function File} {@var{y} =} downsample (@var{x}, @var{n})
-## @deftypefnx {Function File} {@var{y} =} downsample (@var{x}, @var{n}, @var{offset})
+## @deftypefnx {Function File} {@var{y} =} downsample (@var{x}, @var{n}, @var{phase})
 ## Downsample the signal, selecting every @var{n}th element.  If @var{x}
 ## is a matrix, downsample every column.
 ##
-## For most signals you will want to use @code{decimate} instead since
-## it prefilters the high frequency components of the signal and
-## avoids aliasing effects.
+## The optional argument @var{phase} specifies the offset (0 to @var{n}-1) for
+## the starting point of the downsampled sequence.  The default value is 0.
 ##
-## If @var{offset} is defined, select every @var{n}th element starting at
-## sample @var{offset}.
+## @strong{Note:} This function performs simple sample selection without
+## anti-aliasing filtering.  For applications where aliasing may be a concern,
+## consider using @code{decimate} instead.
 ## @seealso{decimate, interp, resample, upfirdn, upsample}
 ## @end deftypefn
 
 function y = downsample (x, n, phase = 0)
 
-  if nargin<2 || nargin>3, print_usage; endif
+  if (nargin < 2 || nargin > 3)
+    print_usage ();
+  endif
 
-  if phase > n - 1
-    warning("This is incompatible with Matlab (phase = 0:n-1). See octave-forge signal package release notes for details.")
+  if (! (isvector (x) || ismatrix (x)))
+    error ("downsample: X must be a vector or matrix");
+  endif
+
+  if (! (isscalar (n) && n > 0 && fix (n) == n))
+    error ("downsample: N must be a positive integer");
+  endif
+
+  if (! (isscalar (phase) && phase >= 0 && phase < n && fix (phase) == phase))
+    error ("downsample: PHASE must be an integer between 0 and N-1");
   endif
 
   if isvector(x)
@@ -32,6 +42,7 @@ function y = downsample (x, n, phase = 0)
 
 endfunction
 
+%!assert(downsample([],3),[]);
 %!assert(downsample([1,2,3,4,5],2),[1,3,5]);
 %!assert(downsample([1;2;3;4;5],2),[1;3;5]);
 %!assert(downsample([1,2;3,4;5,6;7,8;9,10],2),[1,2;5,6;9,10]);

--- a/inst/findpeaks.m
+++ b/inst/findpeaks.m
@@ -201,7 +201,7 @@ function [pks idx varargout] = findpeaks (data, varargin)
 
   ## Treat peaks separated less than minD as one
   D  = abs (bsxfun (@minus, idx_s, idx_s.'));
-  D += diag(NA(1,size(D,1)));                # eliminate diagonal cpmparison
+  D += diag(NA(1,size(D,1)));                # eliminate diagonal comparison
   if (any (D(:) < minD))
 
     i          = 1;

--- a/inst/marcumq.m
+++ b/inst/marcumq.m
@@ -318,7 +318,7 @@ endfunction
 %! q = marcumq (a, b);
 %! assert (q, Q, 1e-6);
 
-## The tests for M>1 were generating from Marcum's tables by
+## The tests for M>1 were generated from Marcum's tables by
 ## using the formula
 ##   Q_M(a,b) = Q(a,b) + exp(-(a-b)^2/2)*sum_{k=1}^{M-1}(b/a)^k*exp(-ab)*I_k(ab)
 

--- a/inst/tukeywin.m
+++ b/inst/tukeywin.m
@@ -19,7 +19,7 @@
 ## @deftypefnx {Function File} {} tukeywin (@var{m}, @var{r})
 ## Return the filter coefficients of a Tukey window (also known as the
 ## cosine-tapered window) of length @var{m}.  @var{r} defines the ratio
-## between the constant section and and the cosine section.  It has to be
+## between the constant section and the cosine section.  It has to be
 ## between 0 and 1.  The function returns a Hanning window for @var{r}
 ## equal to 1 and a rectangular window for @var{r} equal to 0.
 ## The default value of @var{r} is 1/2.

--- a/inst/vco.m
+++ b/inst/vco.m
@@ -22,7 +22,7 @@
 ## Inputs:
 ## @itemize
 ## @item
-## @var{x} - input data with a range of -1 to 1. A value of -1 means no output, 0 cuoreesponds to @var{fc},
+## @var{x} - input data with a range of -1 to 1. A value of -1 means no output, 0 corresponds to @var{fc},
 ## and 1 corresponds to 2*@var{fc}.
 ##
 ## @item
@@ -42,7 +42,7 @@
 ## @end itemize
 ## @end deftypefn
 
-function [y,yn] = vco (x, fc = [], fs = [])
+function y = vco (x, fc = [], fs = [])
 
   if (nargin < 1 || nargin > 3)
     print_usage ();
@@ -109,4 +109,3 @@ endfunction
 
 %!error vco
 %!error vco([1 2])
-

--- a/inst/wkeep.m
+++ b/inst/wkeep.m
@@ -27,7 +27,7 @@ function y = wkeep(x,l,opt = 'c')
   if(isvector(x))
 
     if(l > length(x))
-      error('l must be or equal the size of x');
+      error('l must be less than or equal to the length of x');
     endif
 
     if(opt=='c')

--- a/inst/xcorr2.m
+++ b/inst/xcorr2.m
@@ -63,7 +63,7 @@ function c = xcorr2 (a, b, biasflag = "none")
     b = a;
   endif
   if (ndims (a) != 2 || ndims (b) != 2)
-    error ("xcorr2: input matrices must must have only 2 dimensions");
+    error ("xcorr2: input matrices must have only 2 dimensions");
   endif
 
   ## compute correlation

--- a/inst/zp2sos.m
+++ b/inst/zp2sos.m
@@ -43,7 +43,7 @@
 ## @code{@var{B1}.' = [b0 b1 b2] and @var{A1}.' = [a0 a1 a2]} for
 ## section 1, etc.
 ## See @code{filter} for documentation of the second-order direct-form filter
-## coefficients @var{B}i and %@var{A}i, i=1:N.
+## coefficients @var{B}i and @var{A}i, i=1:N.
 ##
 ## @item
 ## @var{g} is the overall gain factor that effectively scales
@@ -188,6 +188,7 @@ function [SOS,G] = zp2sos(z,p,k,DoNotCombineReal)
   else
     G = k;
   endif
+endfunction
 
 %!test
 %! B=[1 0 0 0 0 1]; A=[1 0 0 0 0 .9];


### PR DESCRIPTION
Enhanced the downsample function by adding input validation for arguments x, n, and phase. Updated documentation.
To some extent, there is an issue regarding `warning("This is incompatible with Matlab (phase = 0:n-1). See octave-forge signal package release notes for details.")` What is the reason about this, and is it intentional?