### PR TITLE
gauspuls: support `bwr` input, return `yi,yq,ye`

### DIFF
--- a/inst/gauspuls.m
+++ b/inst/gauspuls.m
@@ -16,16 +16,41 @@
 ## <https://www.gnu.org/licenses/>.
 
 ## -*- texinfo -*-
-## @deftypefn  {Function File} {@var{y} =} gauspuls (@var{t})
-## @deftypefnx {Function File} {@var{y} =} gauspuls (@var{t}, @var{fc})
-## @deftypefnx {Function File} {@var{y} =} gauspuls (@var{t}, @var{fc}, @var{bw})
+## @deftypefn  {Function File} {@var{yi} =} gauspuls (@var{t})
+## @deftypefnx {Function File} {@var{yi} =} gauspuls (@var{t}, @var{fc})
+## @deftypefnx {Function File} {@var{yi} =} gauspuls (@var{t}, @var{fc}, @var{bw})
+## @deftypefnx {Function File} {@var{yi} =} gauspuls (@var{t}, @var{fc}, @var{bw}, @var{bwr})
+## @deftypefnx {Function File} {[@var{yi}, @var{yq}] =} gauspuls (@dots{})
+## @deftypefnx {Function File} {[@var{yi}, @var{yq}, @var{ye}] =} gauspuls (@dots{})
 ## Generate a Gaussian modulated sinusoidal pulse sampled at times @var{t}.
+##
+## The input arguments are:
+## @itemize
+## @item @var{t} : vector of time values (in seconds) at which the pulse is
+## evaluated.
+## @item @var{fc} : center frequency in Hz (default 1000).  Must be a
+## non-negative real scalar.
+## @item @var{bw} : fractional bandwidth (default 0.5).  Must be a positive
+## real scalar.  The bandwidth is measured at the reference level given by
+## @var{bwr}.
+## @item @var{bwr} : reference level in dB (default -6).  Must be a negative
+## real scalar.  The pulse's envelope amplitude at the band edges is
+## @code{10^(@var{bwr}/20)} times the peak amplitude.
+## @end itemize
+##
+## The output arguments are:
+## @itemize
+## @item @var{yi} : inphase (cosine) component of the pulse.
+## @item @var{yq} : quadrature (sine) component of the pulse.
+## @item @var{ye} : envelope of the pulse 
+## (same as @code{sqrt (@var{yi}.^2 + @var{yq}.^2)}).
+## @end itemize
 ## @seealso{pulstran, rectpuls, tripuls}
 ## @end deftypefn
 
-function y = gauspuls (t, fc = 1e3, bw = 0.5)
+function [yi, yq, ye] = gauspuls (t, fc = 1000, bw = 0.5, bwr = -6)
 
-  if (nargin < 1 || nargin > 3)
+  if (nargin < 1 || nargin > 4)
     print_usage ();
   endif
 
@@ -37,9 +62,14 @@ function y = gauspuls (t, fc = 1e3, bw = 0.5)
     error ("gauspuls: BW must be a positive real scalar")
   endif
 
-  fv = -(bw^2 * fc^2) / (8 * log (10 ^ (-6/20)));
-  tv = 1 / (4*pi^2 * fv);
-  y = exp (-t .* t / (2*tv)) .* cos (2*pi*fc * t);
+  if (! isreal (bwr) || ! isscalar (bwr) || bwr >= 0)
+    error ("gauspuls: BWR must be a negative real scalar");
+  endif
+
+  tv = (-bwr * log (10) / 10) / (pi^2 * bw^2 * fc^2);
+  ye = exp (-t .* t / (2 * tv));
+  yi = ye .* cos (2 * pi * fc * t);
+  yq = ye .* sin (2 * pi * fc * t);
 
 endfunction
 
@@ -59,7 +89,21 @@ endfunction
 
 ## Test input validation
 %!error gauspuls ()
-%!error gauspuls (1, 2, 3, 4)
-%!error gauspuls (1, -1)
-%!error gauspuls (1, 2j)
-%!error gauspuls (1, 1e3, 0)
+%!error gauspuls (1, 2, 3, 4, 5)
+%!error <FC must be a non-negative real scalar> gauspuls (1, -1)
+%!error <FC must be a non-negative real scalar> gauspuls (1, 2j)
+%!error <BW must be a positive real scalar> gauspuls (1, 1e3, 0)
+%!error <BW must be a positive real scalar> gauspuls (1, 1e3, -1)
+%!error <BW must be a positive real scalar> gauspuls (1, 1e3, 0.5j)
+%!error <BWR must be a negative real scalar> gauspuls (1, 1e3, 0.5, 0)
+%!error <BWR must be a negative real scalar> gauspuls (1, 1e3, 0.5, 1)
+%!error <BWR must be a negative real scalar> gauspuls (1, 1e3, 0.5, -2j)
+
+%!test
+%! ## Check that default bwr = -6 yields same as old version
+%! t = linspace (-1, 1, 100);
+%! yi_new = gauspuls (t, 100, 0.5);
+%! tv_old = (-(-6) * log (10) / 10) / (pi^2 * 0.5^2 * 100^2);
+%! ye_old = exp (-t .* t / (2 * tv_old));
+%! yi_old = ye_old .* cos (2 * pi * 100 * t);
+%! assert (yi_new, yi_old, 1e-12);


### PR DESCRIPTION
Update gauspuls to accept an additional bwr argument (default -6 dB) and return separate in-phase, quadrature and envelope outputs (yi, yq, ye) instead of a single y. `yi` is the old `y`.

The following improvements are made:

- **New input argument `bwr`**:  
  Allows the user to specify the reference level (in dB) at which the fractional bandwidth `bw` is measured. The default value is `-6 dB`. In the original function, `fv = -(bw^2 * fc^2) / (8 * log(10 ^ (-6/20)));` where `-6` cannot be modified here.

- **New output arguments**:  
  The function now supports up to three output arguments:
  - `yi` – in-phase component (Gaussian-modulated cosine)
  - `yq` – quadrature component (Gaussian-modulated sine)
  - `ye` – envelope (same as `sqrt(yi.^2 + yq.^2)`)

  If only one output is requested, `yi` is returned (backward-compatible).

- **Updated documentation (`texinfo`)**:  
  The help text is expanded to clearly describe all input and output arguments, their defaults, and the mathematical relationship between them.

These changes bring it closer to the behavior of the corresponding MATLAB function.