### PR TITLE
Add lar2rc, rc2lar, is2rc and rc2is functions

### DIFF
--- a/inst/is2rc.m
+++ b/inst/is2rc.m
@@ -1,0 +1,57 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {@var{k} =} is2rc (@var{is})
+##
+## Convert inverse sine parameters to reflection coefficients.
+##
+## The inverse sine parameters @var{k} (real numeric vector or matrix)
+## are converted to reflection coefficients @var{is} using the formula:
+##
+## @example
+## k(i) = sin((pi / 2) * is(i))
+## @end example
+##
+## @seealso{rc2is}
+## @end deftypefn
+
+function k = is2rc (is)
+
+  if (nargin != 1)
+    print_usage ();
+  endif
+
+  if (! isnumeric (is) || ! isreal (is))
+    error ("is2rc: IS must be a real numeric array.");
+  endif
+
+  k = sin((pi / 2) * is);
+
+endfunction
+
+%!test
+%! ## Vector test
+%! is = [0.2 0.4 1.6 -3 -0.5];
+%! assert (is2rc (is), sin((pi / 2) * is), eps);
+%!
+%! ## Matrix test
+%! k = [0.5, 1.0; -0.5, 0.0];
+%! assert (is2rc (k), sin((pi / 2) * k), eps);
+
+%!error is2rc ()
+%!error is2rc (1, 2)
+%!error is2rc (1 + 1i)

--- a/inst/lar2rc.m
+++ b/inst/lar2rc.m
@@ -1,0 +1,57 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {@var{k} =} lar2rc (@var{g})
+##
+## Convert log area ratio to reflection coefficients.
+##
+## The log area ratio parameters @var{g} (real numeric vector or matrix)
+## are converted to reflection coefficients @var{k} using the formula:
+##
+## @example
+## k(i) = -tanh(-g(i) / 2)
+## @end example
+##
+## @seealso{rc2lar}
+## @end deftypefn
+
+function k = lar2rc (g)
+
+  if (nargin != 1)
+    print_usage ();
+  endif
+
+  if (! isnumeric (g) || ! isreal (g))
+    error ("lar2rc: G must be a real numeric array.");
+  endif
+
+  k = -tanh (-g / 2);
+
+endfunction
+
+%!test
+%! ## Vector test
+%! g = [0.2 0.4 1.6 -3 -0.5];
+%! assert (lar2rc (g), -tanh (-g / 2), eps);
+%!
+%! ## Matrix test
+%! g = [0.5, 1.0; -0.5, 0.0];
+%! assert (lar2rc (g), -tanh (-g / 2), eps);
+
+%!error rc2lar ()
+%!error rc2lar (1, 2)
+%!error rc2lar (1 + 1i)

--- a/inst/rc2is.m
+++ b/inst/rc2is.m
@@ -1,0 +1,57 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {@var{is} =} rc2is (@var{k})
+##
+## Convert reflection coefficients to inverse sine parameters.
+##
+## The reflection coefficients @var{k} (real numeric vector or matrix)
+## are converted to inverse sine parameters @var{is} using the formula:
+##
+## @example
+## is(i) = (2 / pi) * asin(k(i))
+## @end example
+##
+## @seealso{is2rc}
+## @end deftypefn
+
+function is = rc2is (k)
+
+  if (nargin != 1)
+    print_usage ();
+  endif
+
+  if (! isnumeric (k) || ! isreal (k))
+    error ("rc2is: K must be a real numeric array.");
+  endif
+
+  is = (2 / pi) * asin(k);
+
+endfunction
+
+%!test
+%! ## Vector test
+%! k = [0.2 0.4 1.6 -3 -0.5];
+%! assert (rc2is (k), (2 / pi) * asin(k), eps);
+%!
+%! ## Matrix test
+%! k = [0.5, 1.0; -0.5, 0.0];
+%! assert (rc2is (k), (2 / pi) * asin(k), eps);
+
+%!error rc2is ()
+%!error rc2is (1, 2)
+%!error rc2is (1 + 1i)

--- a/inst/rc2lar.m
+++ b/inst/rc2lar.m
@@ -1,0 +1,57 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {@var{g} =} rc2lar (@var{k})
+##
+## Convert reflection coefficients to log area ratio.
+##
+## The reflection coefficients @var{k} (real numeric vector or matrix)
+## are converted to log area ratio parameters @var{g} using the formula:
+##
+## @example
+## g(i) = -2 * atanh(-k(i))
+## @end example
+##
+## @seealso{lar2rc}
+## @end deftypefn
+
+function g = rc2lar (k)
+
+  if (nargin != 1)
+    print_usage ();
+  endif
+
+  if (! isnumeric (k) || ! isreal (k))
+    error ("rc2lar: K must be a real numeric array.");
+  endif
+
+  g = -2 * atanh(-k);
+
+endfunction
+
+%!test
+%! ## Vector test
+%! k = [0.2 0.4 1.6 -3 -0.5];
+%! assert (rc2lar (k), -2 * atanh(-k), eps);
+%!
+%! ## Matrix test
+%! k = [0.5, 1.0; -0.5, 0.0];
+%! assert (rc2lar (k), -2 * atanh(-k), eps);
+
+%!error rc2lar ()
+%!error rc2lar (1, 2)
+%!error rc2lar (1 + 1i)


### PR DESCRIPTION
**Note**: I have not modified the index file, and I am not sure under which category I should place these four functions in the index file.
## Description  
This PR adds four simple functions: 

- `lar2rc`: Log Area Ratio → Reflection coefficients
- `rc2lar`: Reflection coefficients → Log Area Ratio
- `is2rc`: Inverse sine parameters → Reflection coefficients
- `rc2is`: Reflection coefficients → Inverse sine parameters

The conversion is mathematically just one line each:  

```matlab
k = -tanh(-g / 2)
g = -2 * atanh(-k)
k = sin((pi / 2) * is)
is = (2 / pi) * asin(k)
```