### PR TITLE
medfilt1: Add input validation to prevent integer overflow in window size(bug #66990)

### DIFF
--- a/src/medfilt1.cc
+++ b/src/medfilt1.cc
@@ -340,6 +340,9 @@ to bring them up to size @var{n}.\n\
             error ("medfilt1: N must be a real scalar");
           else
             n = args(1).idx_type_value ();
+
+          if (n < 0)
+            error ("medfilt1: N must be a positive integer");
         }
       else
         error ("medfilt1: Invalid type for N: %s",


### PR DESCRIPTION
Maybe fix [bug #66990](https://savannah.gnu.org/bugs/?66990): medfilt1 crashes with AddressSanitizer when window size N is negative.
### Problem
When calling like `medfilt1(x, -1)` with a negative window size, the function attempts to allocate a buffer of `SIZE_MAX-1` , causing:
- AddressSanitizer: `requested allocation size 0xffffffffffffffff`
- Octave on my computer(Windows): `error: out of memory or dimension too large for Octave's index type`

His issue is that the error is catched by ASAN at first rather than catched by Octave in the test `%! error medfilt1(x, -1)`. Therefore, his execution of `test medfilt1` will fail. (I’m not entirely sure about the underlying principle).
