### PR TITLE
interp: add second optional output

### DIFF
--- a/inst/interp.m
+++ b/inst/interp.m
@@ -18,10 +18,14 @@
 ## @deftypefn  {Function File} {@var{y} =} interp (@var{x}, @var{q})
 ## @deftypefnx {Function File} {@var{y} =} interp (@var{x}, @var{q}, @var{n})
 ## @deftypefnx {Function File} {@var{y} =} interp (@var{x}, @var{q}, @var{n}, @var{Wc})
+## @deftypefnx {Function File} {[@var{y}, @var{b}] =} interp (@dots{}})
 ##
 ## Upsample the signal x by a factor of q, using an order 2*q*n+1 FIR
 ## filter. Note that q must be an integer for this rate change method.
 ## n defaults to 4 and Wc defaults to 0.5.
+##
+## The optional second output @var{b} is the FIR filter coefficients
+## used for interpolation.
 ##
 ## Example
 ## @example
@@ -38,9 +42,10 @@
 ## @seealso{decimate, resample}
 ## @end deftypefn
 
-function y = interp(x, q, n = 4, Wc = 0.5)
-
-  if nargin < 1 || nargin > 4,
+function [y, b] = interp(x, q, n = 4, Wc = 0.5)
+  ## FIXME:this results is differnt from MATLAB's,
+  ## maybe someone can make it compatible.
+  if nargin < 2 || nargin > 4,
     print_usage;
   endif
   if q != fix(q), error("decimate only works with integer q."); endif
@@ -60,9 +65,14 @@ endfunction
 %!demo
 %! ## Generate a signal.
 %! t=0:0.01:2; x=chirp(t,2,.5,10,'quadratic')+sin(2*pi*t*0.4);
-%! y = interp(x(1:4:length(x)),4,4,1);   # interpolate a sub-sample
+%! [y, b] = interp(x(1:4:length(x)),4,4,1);   # interpolate a sub-sample
+%! subplot(2,1,1);
 %! plot(t(1:121)*1000,y(1:121),"r-+;Interpolated;"); hold on;
 %! stem(t(1:4:121)*1000,x(1:4:121),"ob;Original;"); hold off;
+%! subplot(2,1,2);
+%! stem(0:length(b)-1, b);
+%! title("Low-pass Interpolation Filter");
+%! xlabel("Sample index");
 %!
 %! % graph shows interpolated signal following through the
 %! % sample points of the original signal.

--- a/inst/interp.m
+++ b/inst/interp.m
@@ -59,6 +59,7 @@ function [y, b] = interp(x, q, n = 4, Wc = 0.5)
   b = fir1(2*q*n+1, Wc/q);
   y=q*fftfilt(b, y);
   y(1:q*n+1) = [];  # adjust for zero filter delay
+  b =b(:);
 
 endfunction
 


### PR DESCRIPTION
The `interp` function in MATLAB has a second output `b`, which returns the interpolation filter coefficients as a column vector.

The reason I did not add the test section is that I found the function’s execution result is different from MATLAB’s.