### PR TITLE
Fix color indexing in zplane.m plot function(fix #20)

### DIFF
--- a/inst/zplane.m
+++ b/inst/zplane.m
@@ -110,7 +110,7 @@ function plot_with_labels (x, symbol)
   if (! isempty(x))
     colors = get (gca (), "colororder");
     for c = 1:columns (x)
-      color = colors(mod (c, rows (colors)), :);
+      color = colors(mod (c-1, rows (colors))+1, :);
       plot (real (x(:,c)), imag (x(:,c)), "color", color, ...
             "linestyle", "none", "marker", symbol);
 


### PR DESCRIPTION
This properly cycles through colors:

c=1 → mod(0, n)+1 = 1

c=2 → mod(1, n)+1 = 2

c=n → mod(n-1, n)+1 = n

c=n+1 → mod(n, n)+1 = 1