### PR TITLE
Add `ac2poly` function and add matrix support for `levinson`

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -171,6 +171,7 @@ Window Functions
   window
   wvtool
 System Identification
+  ac2poly
   arburg
   aryule
   invfreq

--- a/inst/ac2poly.m
+++ b/inst/ac2poly.m
@@ -1,0 +1,54 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {@var{a} =} ac2poly (@var{r})
+## @deftypefnx {Function File} {[@var{a}, @var{e}] =} ac2poly (@var{r})
+## Convert autocorrelation sequence to prediction polynomial.
+##
+## Compute the prediction filter coefficients @var{a} from the autocorrelation
+## sequence @var{r} using the Levinson-Durbin recursion. The second optional
+## output @var{e} returns the final prediction error power.
+##
+## This function directly calls @code{levinson}.
+##
+## @seealso{levinson, poly2ac}
+## @end deftypefn
+
+function [a, e] = ac2poly (r)
+
+  if (nargin != 1)
+    print_usage ();
+  endif
+
+  if (!isnumeric (r) || !(isvector (r) || ismatrix (r)))
+    error ("ac2poly: R must be a numeric vector or matrix.");
+  endif
+
+  [a, e] = levinson (r);
+
+endfunction
+
+%!error ac2poly()
+%!error ac2poly(1,2)
+%!error <numeric vector or matrix> ac2poly("abc")
+%!error <numeric vector or matrix> ac2poly({1,2,3})
+
+%!test
+%! r = [3, -1, -4, 3, 1, -2];
+%! [a, e] = ac2poly(r);
+%! assert (a, [1,-2.8281,-1.9687,-0.1875,1.0312,3.6719], 1e-4);
+%! assert (e, 6.8281, 1e-4);

--- a/inst/ac2poly.m
+++ b/inst/ac2poly.m
@@ -25,7 +25,7 @@
 ##
 ## This function directly calls @code{levinson}.
 ##
-## @seealso{levinson, poly2ac}
+## @seealso{levinson}
 ## @end deftypefn
 
 function [a, e] = ac2poly (r)
@@ -52,3 +52,10 @@ endfunction
 %! [a, e] = ac2poly(r);
 %! assert (a, [1,-2.8281,-1.9687,-0.1875,1.0312,3.6719], 1e-4);
 %! assert (e, 6.8281, 1e-4);
+
+%!test
+%! r = [3, -1, -4, 3, 1, -2];
+%! [a, e] = ac2poly([r', r']);
+%! assert (a(1, :), [1,-2.8281,-1.9687,-0.1875,1.0312,3.6719], 1e-4);
+%! assert (a(2, :), [1,-2.8281,-1.9687,-0.1875,1.0312,3.6719], 1e-4);
+%! assert (e, [6.8281;6.8281], 1e-4);

--- a/inst/levinson.m
+++ b/inst/levinson.m
@@ -45,23 +45,48 @@
 ##    Copyright (C) 1995 Friedrich Leisch <Friedrich.Leisch@ci.tuwien.ac.at>
 ##    GPL license
 
-## FIXME: Matlab doesn't return reflection coefficients and
-##        errors in addition to the polynomial a.
 ## FIXME: What is the difference between aryule, levinson,
 ##        ac2poly, ac2ar, lpc, etc.?
 
 function [a, v, ref] = levinson (acf, p)
 
-  if ( nargin<1 )
-    print_usage;
-  elseif( ~isvector(acf) || length(acf)<2 )
-    error( "levinson: arg 1 (acf) must be vector of length >1\n");
-  elseif ( nargin>1 && ( ~isscalar(p) || fix(p)~=p ) )
-    error( "levinson: arg 2 (p) must be integer >0\n");
-  else
-    if ((nargin == 1)||(p>=length(acf))) p = length(acf) - 1; endif
-    if( columns(acf)>1 ) acf=acf(:); endif      # force a column vector
+  if (nargin < 1 || nargin > 2)
+    print_usage ();
+  endif
 
+  if (isempty (acf) || !(isvector (acf) || ismatrix (acf)))
+    error("levinson: arg 1 (acf) must be a non-empty vector or matrix.");
+  endif
+
+  if (isvector (acf))
+    acf = acf(:);  # force to a column vector
+  endif
+  [row, col] = size (acf);
+  if (nargin < 2 || p >= row)
+    p = row - 1;
+  endif
+  if (nargin > 1 && (!isscalar (p) || fix (p) != p || p < 0 ))
+    if (fix (p) != p)
+      p = floor (p);  ## for compatibility
+    else
+      error("levinson: arg 2 (p) must be a non-negative integer.");
+    endif
+  endif
+
+  ## If acf is a scalar, or if p=0, algorithm gives error.
+  ## These cases are trivial, so just return the trivial solution in these cases.
+  if (numel (acf) == 1 || p == 0)
+    a = ones(col, 1); v = real(acf(1,:)); ref = zeros(0, col); return;
+  endif
+
+  a_result = zeros(col, p+1);
+  v_result = zeros(col, 1);
+  ref_result = zeros(p, col);
+  acf_orig = acf;
+
+  for idx = 1:col
+
+    acf = acf_orig(:, idx);
     if nargout < 3 && p < 100
       ## direct solution [O(p^3), but no loops so slightly faster for small p]
       ##   Kay & Marple Eqn (2.39)
@@ -84,7 +109,94 @@ function [a, v, ref] = levinson (acf, p)
         ref(t) = g;
       endfor
       a = [1, a];
+      ref_result(:, idx) = ref;
     endif
-  endif
+    a_result(idx, :) = a;
+    v_result(idx) = v;
+  endfor
 
+  a = a_result;
+  v = v_result;
+  ref = ref_result;
 endfunction
+
+%!error levinson ()
+%!error levinson (1, 1, 1)
+%!error levinson ([])
+%!error <non-negative integer> levinson ([1, 0.5], -1)
+%!error <non-negative integer> levinson ([1, 0.5], [1, 2])
+
+%!shared x
+%! x = [1, 3, 3, 1];
+
+%!test
+%! ## default n
+%! [a,b,c] = levinson (x);
+%! assert (a, [1, 0, 0, -1]);
+%! assert (b, 0);
+%! assert (c, [-3; -0.75; -1]);
+
+%!test
+%! ## n = 1
+%! [a,b,c] = levinson (x, 1);
+%! assert (a, [1, -3]);
+%! assert (b, -8);
+%! assert (c, -3);
+
+%!test
+%! ## n = 2
+%! [a,b,c] = levinson (x, 2);
+%! assert (a, [1, -0.75, -0.75]);
+%! assert (b, -3.5);
+%! assert (c, [-3; -0.75]);
+
+%!test
+%! ## n = 4 (>= length(r)-1) should use default n = length(r)-1 = 3
+%! [a,b,c] = levinson (x, 4);
+%! assert (a, [1, 0, 0, -1]);
+%! assert (b, 0);
+%! assert (c, [-3; -0.75; -1]);
+
+%!test
+%! ## n = 0 return trivial solution
+%! [a,b,c] = levinson (x, 0);
+%! assert (a, 1);
+%! assert (b, 1);
+%! assert (c, zeros(0, 1));
+
+%!test
+%! ## column vector
+%! [a,b,c] = levinson (x');
+%! assert (a, [1, 0, 0, -1]);
+%! assert (b, 0);
+%! assert (c, [-3; -0.75; -1]);
+
+%!test
+%! ## Matrix input default n
+%! matrix = [x', x'];
+%! [a, b, c] = levinson (matrix);
+%! assert (a, [1, 0, 0, -1; 1, 0, 0, -1]);
+%! assert (b, [0; 0]);
+%! assert (c, [-3, -3; -0.75, -0.75; -1, -1]);
+
+%!test
+%! ## Matrix input with n not default
+%! matrix = [x', x'];
+%! [a, b, c] = levinson (matrix, 2);
+%! assert (a, [1, -0.75, -0.75; 1, -0.75, -0.75]);
+%! assert (b, [-3.5; -3.5]);
+%! assert (c, [-3, -3; -0.75, -0.75]);
+
+%!test
+%! ## direct solve method 
+%! [a, b] = levinson (x, 2);
+%! assert (a, [1, -0.75, -0.75]);
+%! assert (b, -3.5);
+
+%!test
+%! ## Complex input
+%! r = [2 + 0i; 1 + 1i; 0.2 - 0.1i];
+%! [a, b, c] = levinson (r, 2);
+%! assert (a, [1, -0.95-1.15i, -0.2+1.1i], 1e-4);
+%! assert (b, -0.25, 1e-4);
+%! assert (c, [-0.5-0.5i; -0.2+1.1i], 1e-4);


### PR DESCRIPTION
Introduce `ac2poly`: a new function that converts an autocorrelation sequence r into a prediction polynomial a using the Levinson–Durbin recursion . The function returns an optional prediction error e.
This function directly calls `levinson`, so in order to make `ac2poly` support matrix inputs, I also modified `levinson` to support matrix inputs.