### PR TITLE
upfirdn: allow p and q optional for compatibility

### DIFF
--- a/src/upfirdn.cc
+++ b/src/upfirdn.cc
@@ -74,6 +74,32 @@ DEFUN_DLD (upfirdn, args,,
 @deftypefnx {Loadable Function} {@var{y} =} upfirdn (@var{x}, @var{h}, @var{p})\n\
 @deftypefnx {Loadable Function} {@var{y} =} upfirdn (@var{x}, @var{h}, @var{p}, @var{q})\n\
 Upsample, FIR filtering, and downsample.\n\
+\n\
+@var{x} is the input and @var{y} is the output. The function performs three operations:\n\
+@enumerate\n\
+@item Upsample the input @var{x} by a factor of @var{p} (insert zeros).\n\
+@item FIR filter the upsampled signal with the impulse response @var{h}.\n\
+@item Downsample the result by a factor of @var{q} (keep every @var{q}-th sample).\n\
+@end enumerate\n\
+\n\
+Other input parameters:\n\
+\n\
+@table @var\n\
+@item h\n\
+FIR filter impulse response, specified as a vector.  The filter is applied\n\
+after upsampling and before downsampling.\n\
+\n\
+@item p\n\
+Upsampling factor, should be a positive integer.  @code{@var{p} = 1}\n\
+means no upsampling.  Default: 1.\n\
+\n\
+@item q\n\
+Downsampling factor, should be a positive integer.  @code{@var{q} = 1}\n\
+means no downsampling.  Default: 1.\n\
+@end table\n\
+\n\
+The FIR filter @var{h} should typically be a lowpass filter designed to\n\
+suppress imaging artifacts (for upsampling) and aliasing (for downsampling).\n\
 @end deftypefn\n")
 {
   octave_value_list retval;

--- a/src/upfirdn.cc
+++ b/src/upfirdn.cc
@@ -70,7 +70,9 @@ MT upfirdn (MT &x, ColumnVector &h, octave_idx_type p, octave_idx_type q)
 
 DEFUN_DLD (upfirdn, args,,
   "-*- texinfo -*-\n\
-@deftypefn {Loadable Function} {@var{y} =} upfirdn (@var{x}, @var{h}, @var{p}, @var{q})\n\
+@deftypefn  {Loadable Function} {@var{y} =} upfirdn (@var{x}, @var{h})\n\
+@deftypefnx {Loadable Function} {@var{y} =} upfirdn (@var{x}, @var{h}, @var{p})\n\
+@deftypefnx {Loadable Function} {@var{y} =} upfirdn (@var{x}, @var{h}, @var{p}, @var{q})\n\
 Upsample, FIR filtering, and downsample.\n\
 @end deftypefn\n")
 {
@@ -78,15 +80,20 @@ Upsample, FIR filtering, and downsample.\n\
 
   const int nargin = args.length ();
 
-  if (nargin != 4)
+  if (nargin < 2 || nargin > 4)
     {
       print_usage ();
       return retval;
     }
 
   ColumnVector h (args (1).vector_value ());
-  octave_idx_type p = args (2).idx_type_value ();
-  octave_idx_type q = args (3).idx_type_value ();
+  octave_idx_type p = 1;
+  octave_idx_type q = 1;
+
+  if (nargin >= 3)
+    p = args (2).idx_type_value ();
+  if (nargin >= 4)
+    q = args (3).idx_type_value ();
 
   // Do the dispatching
   if (octave::signal::isreal (args (0)))
@@ -113,10 +120,10 @@ Upsample, FIR filtering, and downsample.\n\
 /*
 %!assert (isequal (upfirdn (1:100, 1, 1, 1), 1:100))
 %!assert (isequal (upfirdn (1:100, 1, 1, 2), 1:2:100))
+%!assert (isequal (upfirdn (1:100, 1), 1:100))
 
 %% Test input validation
 %!error upfirdn ()
-%!error upfirdn (1,2)
-%!error upfirdn (1,2,3)
+%!error upfirdn (1)
 %!error upfirdn (1,2,3,4,5)
 */


### PR DESCRIPTION
I found this in #31. In MATLAB `rcosdesign`public document, it gives an example
```
...
Upsample and filter the data for pulse shaping.
x = upfirdn(d, b, sps);
...
```
Default p and q is 1. So I make the change.