### PR TITLE
statelevels: plot level lines

### DIFF
--- a/inst/statelevels.m
+++ b/inst/statelevels.m
@@ -186,14 +186,21 @@ function varargout = statelevels (A, varargin)
     f = figure();
     subplot (2, 1, 1);
     plot(A)
+    hold on;
+    colors = get(gca, 'ColorOrder');
+    ## get the second color for plotting the levels
+    secondColor = colors(2, :); 
+    plot([1, length(A)], [S1, S1], '-.', 'Color', secondColor);
+    plot([1, length(A)], [S2, S2], '-.', 'Color', secondColor);
+    hold off;
     title('Signal');
     xlabel('Samples');
-    ylabel('Level');
+    ylabel('Level(Volts)');
 
     subplot (2, 1, 2);
     plot(histVec, histogram);
     title(sprintf('Histogram of signal levels (%d bins)', nBins));
-    xlabel('Level');
+    xlabel('Level(Volts)');
     ylabel('Count');
   endif
 


### PR DESCRIPTION
Draw dashed horizontal lines for S1 and S2 on the signal plot. Update y-axis and histogram x-axis labels to include units ("Volts"). This is closer to the result of MATLAB.
`demo statelevels` shows:
<img width="1460" height="675" alt="untitled" src="https://github.com/user-attachments/assets/a60ab266-8802-47e2-8417-4f96b2323e72" />

