### PR TITLE
Add ac2rc: autocorrelation to reflection coeffs

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -173,6 +173,7 @@ Window Functions
   wvtool
 System Identification
   ac2poly
+  ac2rc
   arburg
   aryule
   invfreq

--- a/inst/ac2rc.m
+++ b/inst/ac2rc.m
@@ -1,0 +1,62 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {[@var{k}, @var{r0}] =} ac2rc (@var{r})
+## Convert autocorrelation sequence to reflection coefficients.
+##
+## Compute the reflection coefficients @var{k} from the autocorrelation
+## sequence @var{r} using the Levinson-Durbin recursion. The second optional
+## output @var{r0} returns the zero-lag autocorrelation @math{r(0)}.
+##
+## This function directly calls @code{levinson}.
+##
+## @seealso{levinson}
+## @end deftypefn
+
+function [k, r0] = ac2rc (r)
+
+  if (nargin != 1)
+    print_usage ();
+  endif
+
+  if (!isnumeric (r) || !(isvector (r) || ismatrix (r)))
+    error ("ac2rc: R must be a numeric vector or matrix.");
+  endif
+
+  [~, ~, k] = levinson (r);
+  r0 = r(1,:).';
+
+endfunction
+
+
+%!error ac2rc()
+%!error ac2rc(1,2)
+%!error <numeric vector or matrix> ac2rc("abc")
+%!error <numeric vector or matrix> ac2rc({1,2,3})
+
+%!test
+%! r = [3, -1, -4, 3, 1, -2];
+%! [k, r0] = ac2rc(r);
+%! assert (k, [0.3333;1.6250;-0.4857;-0.9145;3.6719], 1e-4);
+%! assert (r0, r');
+
+%!test
+%! r = [3, -1, -4, 3, 1, -2];
+%! [k, r0] = ac2rc([r', r']);
+%! assert (k(:,1), [0.3333;1.6250;-0.4857;-0.9145;3.6719], 1e-4);
+%! assert (k(:,2), [0.3333;1.6250;-0.4857;-0.9145;3.6719], 1e-4);
+%! assert (r0, [3;3], 1e-4);


### PR DESCRIPTION
The results I achieved are the same as those from MATLAB. Unfortunately, `ac2rc` and `ac2poly` handle row and column vectors differently, which is reflected in their respective documentation for the same input `r`. It’s not a bug, but a feature, though it is indeed somewhat counterintuitive. Both functions are implemented by directly calling levinson.

ac2rc: `Autocorrelation sequence, specified as a vector or as a matrix. The ac2rc function treats each column of r as a separate channel.`
ac2poly: `Autocorrelation sequence, specified as a vector or as a matrix.
If you specify r as a matrix, ac2poly treats each column of r as a separate channel.`
Therefore, the following results are obtained:
```matlab
>> r = [3, -1, -4, 3, 1, -2];
>> [k, r0] = ac2rc(r)

k =

    0.3333
    1.6250
   -0.4857
   -0.9145
    3.6719


r0 =

     3
    -1
    -4
     3
     1
    -2

>> [k, r0] = ac2rc(r')

k =

    0.3333
    1.6250
   -0.4857
   -0.9145
    3.6719


r0 =

     3
```