### PR TITLE
Add lp2lp, lp2hp, lp2bp, lp2bs functions

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -96,6 +96,10 @@ IIR Filter Design
   invimpinvar
   firpm
   firpmord
+  lp2bp
+  lp2bs
+  lp2hp
+  lp2lp
   ncauer
   pei_tseng_notch
   sftrans

--- a/inst/lp2bp.m
+++ b/inst/lp2bp.m
@@ -18,13 +18,28 @@
 ## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2bp (@var{b}, @var{a}, @var{Wo}, @var{Bw})
 ## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2bp (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo}, @var{Bw})
 ##
-## [bt, at] = lp2bp(b, a, Wo, Bw) transforms an analog lowpass filter in transfer
-## function form to an analog bandpass filter with center frequency Wo and 
-## bandwidth Bw.
+## Transform an analog lowpass filter prototype to a bandpass filter with a
+## given center frequency and bandwidth.
 ##
-## [At,Bt,Ct,Dt] = lp2bp(A, B, C, D, Wo, Bw)  transforms an analog lowpass filter in state
-## space form to an analog bandpass filter with center frequency Wo and 
-## bandwidth Bw.
+## Two calling forms are available:
+##
+## @table @asis
+## @item Transfer function form
+## [bt, at] = lp2bp (b, a, Wo, Bw)
+##
+## Given a lowpass filter with numerator coefficients @var{b} and denominator
+## coefficients @var{a}, returns the bandpass filter coefficients @var{bt}
+## and @var{at} with center frequency @var{Wo} and bandwidth @var{Bw}
+## (both in rad/s).
+##
+## @item State-space form
+## [At, Bt, Ct, Dt] = lp2bp (A, B, C, D, Wo, Bw)
+##
+## Given a lowpass filter in state-space form (@var{A}, @var{B}, @var{C},
+## @var{D}), returns the transformed state-space matrices (@var{At}, @var{Bt},
+## @var{Ct}, @var{Dt}) for the bandpass filter with center frequency @var{Wo}
+## and bandwidth @var{Bw} (both in rad/s).
+## @end table
 ##
 ## @seealso{lp2lp, lp2hp, lp2bs}
 ## @end deftypefn

--- a/inst/lp2bp.m
+++ b/inst/lp2bp.m
@@ -1,0 +1,166 @@
+## Copyright (C) 2021 Tony Richardson <richardson.tony@gmail.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2bp (@var{b}, @var{a}, @var{Wo}, @var{Bw})
+## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2bp (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo}, @var{Bw})
+##
+## [bt, at] = lp2bp(b, a, Wo, Bw) transforms an analog lowpass filter in transfer
+## function form to an analog bandpass filter with center frequency Wo and 
+## bandwidth Bw.
+##
+## [At,Bt,Ct,Dt] = lp2bp(A, B, C, D, Wo, Bw)  transforms an analog lowpass filter in state
+## space form to an analog bandpass filter with center frequency Wo and 
+## bandwidth Bw.
+##
+## @seealso{lp2lp, lp2hp, lp2bs}
+## @end deftypefn
+
+function [At Bt Ct Dt] = lp2bp(A, B, C, D, Wo, Bw)
+
+  if (nargin == 4)
+    ## Transfer function form: [bt, at] = lp2bp(b, a, Wo, Bw)
+    b = A;
+    a = B;
+    Wo = C;
+    Bw = D;
+
+    if (!isvector (b) || !isvector (a))
+      error ("lp2bp: b and a must be vectors.");
+    endif
+    if (!isscalar (Wo) || !isscalar (Bw))
+      error ("lp2bp: Wo and Bw must be scalars.");
+    endif
+
+    [A, B, C, D] = tf2ss (b, a);
+    [At, Bt, Ct, Dt] = lp2bp (A, B, C, D, Wo, Bw);
+    [bt, at] = ss2tf (At, Bt, Ct, Dt);
+
+    bt = bt/at(1);
+    at = at/at(1);
+
+    ## Remove leading zeros from bt
+    first_nonzero = find(bt != 0, 1);
+    if !isempty (first_nonzero)
+      bt = bt(first_nonzero:end);
+    else
+      bt = 0;
+    endif
+
+    At = bt;
+    Bt = at;
+
+  elseif (nargin == 6)
+    ## State-space form: [At, Bt, Ct, Dt] = lp2bp(A, B, C, D, Wo, Bw)
+    if (!ismatrix (A) || !ismatrix (B) || !ismatrix (C) || !ismatrix (D))
+      error ("lp2bp: A, B, C, D must be matrices.");
+    endif
+    if (!isscalar (Wo) || !isscalar (Bw))
+      error ("lp2bp: Wo and Bw must be scalars.");
+    endif
+
+    ## Dimension checks
+    [ma, na] = size (A);
+    if (ma != na)
+      error ("lp2bp: A must be square.");
+    endif
+    [mb, nb] = size (B);
+    if (mb != ma)
+      error ("lp2bp: B must have same number of rows as A.");
+    endif
+    [mc, nc] = size (C);
+    if (nc != ma)
+      error ("lp2bp: C must have same number of columns as A.");
+    endif
+    [md, nd] = size (D);
+    if (md != mc || nd != nb)
+      error ("lp2bp: D dimensions inconsistent with B and C.");
+    endif
+  
+    Q = Wo/Bw;
+    [ma, m] = size(A); n = size(B, 2); mc = size(C, 1);
+    At = Wo*[A/Q eye(ma,m); -eye(ma,m) zeros(ma,m)];
+    Bt = Wo*[B/Q; zeros(ma,n)];
+    Ct = [C zeros(mc,ma)];
+    Dt = D;
+  else
+    print_usage ();
+  endif
+
+endfunction
+
+%!test
+%! b = [1];
+%! a = [1, 1];
+%! [bt, at] = lp2bp(b, a, 2, 3);
+%! assert (bt, [3, 0], 1e-10);
+%! assert (at, [1, 3, 4], 1e-10);
+
+%!test
+%! A = [0, 1; 3, 2];
+%! B = [0; 1];
+%! C = [1, 0];
+%! D = [1];
+%! [At, Bt, Ct, Dt] = lp2bp(A, B, C, D, 10, 5);
+%! assert (At, [0, 5, 10, 0; 15, 10, 0, 10; -10, 0, 0, 0; 0, -10, 0, 0]);
+%! assert (Bt, [0; 5; 0; 0]);
+%! assert (Ct, [1, 0, 0, 0]);
+%! assert (Dt, 1);
+
+%!error lp2bp()
+%!error lp2bp(1)
+%!error lp2bp(1, 2)
+%!error lp2bp(1, 2, 3)
+%!error lp2bp([1, 2; 3, 4], [1, 1], 100, 10)
+
+%!demo
+%! n = 14;
+%! [z p k] = buttap(n);
+%! [b a] = zp2tf(z, p, real(k));
+%!
+%! w = logspace(-1, 1, 501);
+%! H = freqs(b, a, w);
+%! figure(1)
+%! clf
+%! subplot(2, 1, 1)
+%! loglog(w, abs(H))
+%! title("Lowpass Butterworth")
+%! ylim([1e-15 1]);
+%! yticks(logspace(-15, 0, 4))
+%! grid on
+%! subplot(2, 1, 2)
+%! semilogx(w, rad2deg(angle(H)))
+%! grid on
+%!
+%! fl = 30; fh = 100;
+%! Wo = 2*pi*sqrt(fl*fh);
+%! Bw = 2*pi*(fh - fl);
+%! [bt, at] = lp2bp(b, a, Wo, Bw);
+%!
+%! w = logspace(0, 4, 501);
+%! H = freqs(bt, at, w);
+%!
+%! figure(2)
+%! clf
+%! subplot(2, 1, 1)
+%! loglog(w, abs(H))
+%! title("Bandpass filter response")
+%! ylim([1e-20 1]);
+%! yticks(logspace(-20, 0, 3))
+%! grid on
+%! subplot(2, 1, 2)
+%! semilogx(w, rad2deg(angle(H)))
+%! grid on

--- a/inst/lp2bs.m
+++ b/inst/lp2bs.m
@@ -17,15 +17,29 @@
 ## -*- texinfo -*-
 ## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2bs (@var{b}, @var{a}, @var{Wo}, @var{Bw})
 ## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2bs (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo}, @var{Bw})
-## Transform lowpass filter to bandstop filter.
 ##
-## [bt, at] = lp2bs(b, a, Wo, Bw) transforms an analog lowpass filter in transfer
-## function form to an analog bandstop filter with center frequency Wo and 
-## bandwidth Bw.
+## Transform an analog lowpass filter prototype to a bandstop filter with a
+## given center frequency and bandwidth.
 ##
-## [At,Bt,Ct,Dt] = lp2bs(A, B, C, D, Wo, Bw) transforms an analog lowpass filter in state
-## space form to an analog bandstop filter with center frequency Wo and 
-## bandwidth Bw.
+## Two calling forms are available:
+##
+## @table @asis
+## @item Transfer function form
+## [bt, at] = lp2bs (b, a, Wo, Bw)
+##
+## Given a lowpass filter with numerator coefficients @var{b} and denominator
+## coefficients @var{a}, returns the bandstop filter coefficients @var{bt}
+## and @var{at} with center frequency @var{Wo} and bandwidth @var{Bw}
+## (both in rad/s).
+##
+## @item State-space form
+## [At, Bt, Ct, Dt] = lp2bs (A, B, C, D, Wo, Bw)
+##
+## Given a lowpass filter in state-space form (@var{A}, @var{B}, @var{C},
+## @var{D}), returns the transformed state-space matrices (@var{At}, @var{Bt},
+## @var{Ct}, @var{Dt}) for the bandstop filter with center frequency @var{Wo}
+## and bandwidth @var{Bw} (both in rad/s).
+## @end table
 ##
 ## @seealso{lp2bp, lp2hp, lp2lp}
 ## @end deftypefn

--- a/inst/lp2bs.m
+++ b/inst/lp2bs.m
@@ -1,0 +1,158 @@
+## Copyright (C) 2021 Tony Richardson <richardson.tony@gmail.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2bs (@var{b}, @var{a}, @var{Wo}, @var{Bw})
+## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2bs (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo}, @var{Bw})
+## Transform lowpass filter to bandstop filter.
+##
+## [bt, at] = lp2bs(b, a, Wo, Bw) transforms an analog lowpass filter in transfer
+## function form to an analog bandstop filter with center frequency Wo and 
+## bandwidth Bw.
+##
+## [At,Bt,Ct,Dt] = lp2bs(A, B, C, D, Wo, Bw) transforms an analog lowpass filter in state
+## space form to an analog bandstop filter with center frequency Wo and 
+## bandwidth Bw.
+##
+## @seealso{lp2bp, lp2hp, lp2lp}
+## @end deftypefn
+
+function [At Bt Ct Dt] = lp2bs(A, B, C, D, Wo, Bw)
+
+  if (nargin == 4)
+    ## Transfer function form: [bt, at] = lp2bs(b, a, Wo, Bw)
+    b = A;
+    a = B;
+    Wo = C;
+    Bw = D;
+
+    if (!isvector (b) || !isvector (a))
+      error ("lp2bs: b and a must be vectors.");
+    endif
+    if (!isscalar (Wo) || !isscalar (Bw))
+      error ("lp2bs: Wo and Bw must be scalars.");
+    endif
+
+    [A, B, C, D] = tf2ss (b, a);
+    [At, Bt, Ct, Dt] = lp2bs (A, B, C, D, Wo, Bw);
+    [bt, at] = ss2tf (At, Bt, Ct, Dt);
+
+    bt = bt/at(1);
+    at = at/at(1);
+
+    ## Remove leading zeros from bt
+    first_nonzero = find(bt != 0, 1);
+    if !isempty (first_nonzero)
+      bt = bt(first_nonzero:end);
+    else
+      bt = 0;
+    endif
+
+    At = bt;
+    Bt = at;
+
+  elseif (nargin == 6)
+    ## State-space form: [At, Bt, Ct, Dt] = lp2bs(A, B, C, D, Wo, Bw)
+    if (!ismatrix (A) || !ismatrix (B) || !ismatrix (C) || !ismatrix (D))
+      error ("lp2bs: A, B, C, D must be matrices.");
+    endif
+    if (!isscalar (Wo) || !isscalar (Bw))
+      error ("lp2bs: Wo and Bw must be scalars.");
+    endif
+
+    ## Dimension checks
+    [ma, na] = size (A);
+    if (ma != na)
+      error ("lp2bs: A must be square.");
+    endif
+    [mb, nb] = size (B);
+    if (mb != ma)
+      error ("lp2bs: B must have same number of rows as A.");
+    endif
+    [mc, nc] = size (C);
+    if (nc != ma)
+      error ("lp2bs: C must have same number of columns as A.");
+    endif
+    [md, nd] = size (D);
+    if (md != mc || nd != nb)
+      error ("lp2bs: D dimensions inconsistent with B and C.");
+    endif
+
+    Q = Wo / Bw;
+    At = [Wo/Q*inv(A) Wo*eye(ma); -Wo*eye(ma) zeros(ma)];
+    Bt = -[Wo/Q*(A\B); zeros(ma,nb)];
+    Ct = [C/A zeros(mc,ma)];
+    Dt = D - C/A*B;
+  else
+    print_usage ();
+  endif
+
+endfunction
+
+%!test
+%! b = [1];
+%! a = [1, 1];
+%! [bt, at] = lp2bs(b, a, 2, 3);
+%! assert (bt, [1, 0, 4], 1e-10);
+%! assert (at, [1, 3, 4], 1e-10);
+
+%!test
+%! A = [0, 1; 3, 2];
+%! B = [0; 1];
+%! C = [1, 0];
+%! D = [1];
+%! [At, Bt, Ct, Dt] = lp2bs(A, B, C, D, 10, 5);
+%! assert (At, [-3.3333, 1.6667, 10, 0; 5, 0, 0, 10; -10, 0, 0, 0; 0, -10.0000, 0, 0],1e-4);
+%! assert (Bt, [-1.6667; 0; 0; 0],1e-4);
+%! assert (Ct, [-0.6667, 0.3333, 0, 0],1e-4);
+%! assert (Dt, 0.6667,1e-4);
+
+%!error lp2bs()
+%!error lp2bs(1)
+%!error lp2bs(1, 2)
+%!error lp2bs(1, 2, 3)
+%!error lp2bs([1, 2; 3, 4], [1, 1], 100, 10)
+
+%!demo
+%! n = 15;
+%! [z p k] = buttap(n);
+%! [b a] = zp2tf(z, p, k);
+%! w = logspace(-1, 1, 501);
+%! H = freqs(b, a, w);
+%! figure(1)
+%! subplot(2, 1, 1)
+%! loglog(w, abs(H))
+%! ylim([1e-15 1]);
+%! yticks(logspace(-15, 0, 4))
+%! title("Lowpass Butterworth")
+%! grid on
+%! subplot(2, 1, 2)
+%! semilogx(w, rad2deg(angle(H)))
+%! grid on
+%!
+%! [bt, at] = lp2bs(b, a, 200, 250);
+%! w = logspace(1, 3, 501);
+%! H = freqs(bt, at, w);
+%! figure(2)
+%! subplot(2, 1, 1)
+%! loglog(w, abs(H))
+%! ylim([1e-20 1]);
+%! yticks(logspace(-20, 0, 3))
+%! title("Bandstop filter response")
+%! grid on
+%! subplot(2, 1, 2)
+%! semilogx(w, rad2deg(angle(H)))
+%! grid on

--- a/inst/lp2hp.m
+++ b/inst/lp2hp.m
@@ -1,0 +1,143 @@
+## Copyright (C) 2021 Tony Richardson <richardson.tony@gmail.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2hp (@var{b}, @var{a}, @var{Wo})
+## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2hp (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo})
+##
+## [bt, at] = lp2hp(b, a, Wo) transforms an analog lowpass filter in transfer
+## function form to an analog highpass filter with a different cutoff frequency (Wo).
+##
+## [At,Bt,Ct,Dt] = lp2hp(A, B, C, D, Wo) transforms an analog lowpass filter in state
+## space form to an analog highpass filter with a different cutoff frequency (Wo).
+## @seealso{lp2lp, lp2bp, lp2bs}
+## @end deftypefn
+
+function [At Bt Ct Dt] = lp2hp(A, B, C, D, Wo)
+
+  if (nargin == 3)
+    ## Transfer function form: [bt, at] = lp2hp(b, a, Wo)
+    b = A;
+    a = B;
+    Wo = C;
+
+    if (!isvector (b) || !isvector (a))
+      error ("lp2hp: b and a must be vectors.");
+    endif
+    if (!isscalar (Wo))
+      error ("lp2hp: Wo must be a scalar.");
+    endif
+
+    [A, B, C, D] = tf2ss (b, a);
+    [At, Bt, Ct, Dt] = lp2hp (A, B, C, D, Wo);
+    [bt, at] = ss2tf (At, Bt, Ct, Dt);
+
+    bt = bt/at(1);
+    at = at/at(1);
+
+    ## Remove leading zeros from bt
+    first_nonzero = find(bt != 0, 1);
+    if !isempty (first_nonzero)
+      bt = bt(first_nonzero:end);
+    else
+      bt = 0;
+    endif
+
+    At = bt;
+    Bt = at;
+
+  elseif (nargin == 5)
+    ## State-space form: [At, Bt, Ct, Dt] = lp2hp(A, B, C, D, Wo)
+    if (!ismatrix (A) || !ismatrix (B) || !ismatrix (C) || !ismatrix (D))
+      error ("lp2hp: A, B, C, D must be matrices.");
+    endif
+    if (!isscalar (Wo))
+      error ("lp2hp: Wo must be a scalar.");
+    endif
+
+    ## Dimension checks
+    [ma, na] = size (A);
+    if (ma != na)
+      error ("lp2hp: A must be square.");
+    endif
+    [mb, nb] = size (B);
+    if (mb != ma)
+      error ("lp2hp: B must have same number of rows as A.");
+    endif
+    [mc, nc] = size (C);
+    if (nc != ma)
+      error ("lp2hp: C must have same number of columns as A.");
+    endif
+    [md, nd] = size (D);
+    if (md != mc || nd != nb)
+      error ("lp2hp: D dimensions inconsistent with B and C.");
+    endif
+
+    At = Wo*inv(A);
+    Bt = -Wo*(A\B);
+    Ct = C/A;
+    Dt = D-C/A*B;
+  else
+    print_usage ();
+  endif
+
+endfunction
+
+%!test
+%! b = [1];
+%! a = [1, 1];
+%! [bt, at] = lp2hp(b, a, 2);
+%! assert (bt, [1, 0], 1e-10);
+%! assert (at, [1, 2], 1e-10);
+
+%!test
+%! A = [0, 1; 3, 2];
+%! B = [0; 1];
+%! C = [1, 0];
+%! D = [1];
+%! [At, Bt, Ct, Dt] = lp2hp(A, B, C, D, 10);
+%! assert (At, [-6.6667, 3.3333; 10, 0],1e-4);
+%! assert (Bt, [-3.3333; 0],1e-4);
+%! assert (Ct, [-0.6667, 0.3333],1e-4);
+%! assert (Dt, 0.6667,1e-4);
+
+%!error lp2hp()
+%!error lp2hp(1)
+%!error lp2hp(1, 2)
+%!error lp2hp([1, 2; 3, 4], [1, 1], 100, 10)
+
+%!demo
+%! f = 100;
+%! [ze pe ke] = ellipap(5, 3, 30);
+%! [be ae] = zp2tf(ze, pe, ke);
+%! 
+%! w = logspace(-2, 1, 501);
+%! H = freqs(be, ae, w);
+%! figure(1)
+%! clf
+%! semilogx(w, 20*log10(abs(H)))
+%! title("Lowpass Elliptic")
+%! grid
+%! 
+%! [bh ah] = lp2hp(be, ae, 2*pi*f);
+%! 
+%! f = logspace(1, 3, 501);
+%! H = freqs(bh, ah, 2*pi*f);
+%! figure(2)
+%! clf
+%! semilogx(f, 20*log10(abs(H)))
+%! title("Highpass filter response")
+%! grid

--- a/inst/lp2hp.m
+++ b/inst/lp2hp.m
@@ -18,11 +18,28 @@
 ## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2hp (@var{b}, @var{a}, @var{Wo})
 ## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2hp (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo})
 ##
-## [bt, at] = lp2hp(b, a, Wo) transforms an analog lowpass filter in transfer
-## function form to an analog highpass filter with a different cutoff frequency (Wo).
+## Transform an analog lowpass filter prototype to a highpass filter with a
+## given cutoff frequency.
 ##
-## [At,Bt,Ct,Dt] = lp2hp(A, B, C, D, Wo) transforms an analog lowpass filter in state
-## space form to an analog highpass filter with a different cutoff frequency (Wo).
+## Two calling forms are available:
+##
+## @table @asis
+## @item Transfer function form
+## [bt, at] = lp2hp (b, a, Wo)
+##
+## Given a lowpass filter with numerator coefficients @var{b} and denominator
+## coefficients @var{a}, returns the highpass filter coefficients @var{bt}
+## and @var{at} with cutoff frequency @var{Wo} (in rad/s).
+##
+## @item State-space form
+## [At, Bt, Ct, Dt] = lp2hp (A, B, C, D, Wo)
+##
+## Given a lowpass filter in state-space form (@var{A}, @var{B}, @var{C},
+## @var{D}), returns the transformed state-space matrices (@var{At}, @var{Bt},
+## @var{Ct}, @var{Dt}) for the highpass filter with cutoff frequency @var{Wo}
+## (in rad/s).
+## @end table
+##
 ## @seealso{lp2lp, lp2bp, lp2bs}
 ## @end deftypefn
 

--- a/inst/lp2lp.m
+++ b/inst/lp2lp.m
@@ -1,0 +1,152 @@
+## Copyright (C) 2021 Tony Richardson <richardson.tony@gmail.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2lp (@var{b}, @var{a}, @var{Wo})
+## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2lp (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo})
+##
+## [bt, at] = lp2lp(b, a, Wo) transforms an analog lowpass filter in transfer
+## function form to an analog lowpass filter with a different cutoff frequency (Wo).
+##
+## [At,Bt,Ct,Dt] = lp2lp(A, B, C, D, Wo) transforms an analog lowpass filter in state
+## space form to an analog lowpass filter with a different cutoff frequency (Wo).
+## @seealso{lp2hp, lp2bp, lp2bs}
+## @end deftypefn
+
+function [At Bt Ct Dt] = lp2lp(A, B, C, D, Wo)
+
+  if (nargin == 3)
+    ## Transfer function form: [bt, at] = lp2lp(b, a, Wo)
+    b = A;
+    a = B;
+    Wo = C;
+
+    if (!isvector (b) || !isvector (a))
+      error ("lp2lp: b and a must be vectors.");
+    endif
+    if (!isscalar (Wo))
+      error ("lp2lp: Wo must be a scalar.");
+    endif
+
+    [A, B, C, D] = tf2ss (b, a);
+    [At, Bt, Ct, Dt] = lp2lp (A, B, C, D, Wo);
+    [bt, at] = ss2tf (At, Bt, Ct, Dt);
+
+    bt = bt/at(1);
+    at = at/at(1);
+
+    ## Remove leading zeros from bt
+    first_nonzero = find(bt != 0, 1);
+    if !isempty (first_nonzero)
+      bt = bt(first_nonzero:end);
+    else
+      bt = 0;
+    endif
+
+    At = bt;
+    Bt = at;
+
+  elseif (nargin == 5)
+    ## State-space form: [At, Bt, Ct, Dt] = lp2lp(A, B, C, D, Wo)
+    if (!ismatrix (A) || !ismatrix (B) || !ismatrix (C) || !ismatrix (D))
+      error ("lp2lp: A, B, C, D must be matrices.");
+    endif
+    if (!isscalar (Wo))
+      error ("lp2lp: Wo must be a scalar.");
+    endif
+
+    ## Dimension checks
+    [ma, na] = size (A);
+    if (ma != na)
+      error ("lp2lp: A must be square.");
+    endif
+    [mb, nb] = size (B);
+    if (mb != ma)
+      error ("lp2lp: B must have same number of rows as A.");
+    endif
+    [mc, nc] = size (C);
+    if (nc != ma)
+      error ("lp2lp: C must have same number of columns as A.");
+    endif
+    [md, nd] = size (D);
+    if (md != mc || nd != nb)
+      error ("lp2lp: D dimensions inconsistent with B and C.");
+    endif
+
+    At = Wo*A;
+    Bt = Wo*B;
+    Ct = C;
+    Dt = D;
+  else
+    print_usage ();
+  endif
+
+endfunction
+
+%!test
+%! b = [1];
+%! a = [1, 1];
+%! [bt, at] = lp2lp(b, a, 2);
+%! assert (bt, 2, 1e-10);
+%! assert (at, [1, 2], 1e-10);
+
+%!test
+%! A = [0, 1; 3, 2];
+%! B = [0; 1];
+%! C = [1, 0];
+%! D = [1];
+%! [At, Bt, Ct, Dt] = lp2lp(A, B, C, D, 10);
+%! assert (At, [0, 10; 30, 20]);
+%! assert (Bt, [0; 10]);
+%! assert (Ct, [1, 0]);
+%! assert (Dt, 1);
+
+%!error lp2lp()
+%!error lp2lp(1)
+%!error lp2lp(1, 2)
+%!error lp2lp([1, 2; 3, 4], [1, 1], 100, 10)
+
+%!demo
+%! [z p k] = cheb1ap(8, 3);
+%! [b a] = zp2tf(z, p, real(k));
+%!
+%! Wo = 2*pi*30;
+%! [bt at] = lp2lp(b, a, Wo);
+%!
+%! w = logspace(-2, 1, 501);
+%! H = freqs(b, a, w);
+%! figure(1)
+%! clf
+%! subplot(2, 1, 1)
+%! loglog(w, abs(H))
+%! title("Lowpass Chebyshev Type I")
+%! grid on
+%! subplot(2, 1, 2)
+%! semilogx(w, rad2deg(angle(H)))
+%! grid on
+%!
+%! w = logspace(0, 3, 501);
+%! H = freqs(bt, at, w);
+%!
+%! figure(2)
+%! clf
+%! subplot(2, 1, 1)
+%! loglog(w, abs(H))
+%! title("Lowpass filter response")
+%! grid on
+%! subplot(2, 1, 2)
+%! semilogx(w, rad2deg(angle(H)))
+%! grid on

--- a/inst/lp2lp.m
+++ b/inst/lp2lp.m
@@ -18,11 +18,27 @@
 ## @deftypefn  {Function File} {[@var{bt}, @var{at}] =} lp2lp (@var{b}, @var{a}, @var{Wo})
 ## @deftypefnx {Function File} {[@var{At}, @var{Bt}, @var{Ct}, @var{Dt}] =} lp2lp (@var{A}, @var{B}, @var{C}, @var{D}, @var{Wo})
 ##
-## [bt, at] = lp2lp(b, a, Wo) transforms an analog lowpass filter in transfer
-## function form to an analog lowpass filter with a different cutoff frequency (Wo).
+## Transform an analog lowpass filter prototype to a lowpass filter with a
+## different cutoff frequency.
 ##
-## [At,Bt,Ct,Dt] = lp2lp(A, B, C, D, Wo) transforms an analog lowpass filter in state
-## space form to an analog lowpass filter with a different cutoff frequency (Wo).
+## Two calling forms are available:
+##
+## @table @asis
+## @item Transfer function form
+## [bt, at] = lp2lp (b, a, Wo)
+##
+## Given a lowpass filter with numerator coefficients @var{b} and denominator
+## coefficients @var{a}, returns the transformed filter coefficients @var{bt}
+## and @var{at} with cutoff frequency @var{Wo} (in rad/s).
+##
+## @item State-space form
+## [At, Bt, Ct, Dt] = lp2lp (A, B, C, D, Wo)
+##
+## Given a lowpass filter in state-space form (@var{A}, @var{B}, @var{C},
+## @var{D}), returns the transformed state-space matrices (@var{At}, @var{Bt},
+## @var{Ct}, @var{Dt}) with cutoff frequency @var{Wo} (in rad/s).
+## @end table
+##
 ## @seealso{lp2hp, lp2bp, lp2bs}
 ## @end deftypefn
 


### PR DESCRIPTION
Introduce four new analog lowpass frequency-transformation utilities. Each function supports both transfer-function and state-space.
The code is modified from [bug #46440](https://savannah.gnu.org/bugs/index.php?46440), or rather it's not really a modification since the mathematical principles of these transformations are publicly available. However, thanks to the original author, richardson.tony@gmail.com, for providing the demo part.
Those original files contain the GPL notice.