### PR TITLE
Add `impzlength` and `stepz` function, enhance `impz`

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -53,6 +53,7 @@ Filter Analysis
   fwhm
   grpdelay
   impz
+  impzlength
   isallpass
   ismaxphase
   isminphase

--- a/INDEX
+++ b/INDEX
@@ -59,6 +59,7 @@ Filter Analysis
   isminphase
   isstable
   phasez
+  stepz
   zplane
 Filter Conversion
   cell2sos

--- a/inst/impz.m
+++ b/inst/impz.m
@@ -1,4 +1,5 @@
 ## Copyright (C) 1999 Paul Kienzle <pkienzle@users.sf.net>
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
 ##
 ## This program is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
@@ -21,21 +22,19 @@
 ## @deftypefnx {Function File} {[@var{x}, @var{t}] =} impz (@var{b}, @var{a}, @var{n}, @var{fs})
 ## @deftypefnx {Function File} {} impz (@dots{})
 ##
-## Generate impulse-response characteristics of the filter. The filter
-## coefficients correspond to the z-plane rational function with
-## numerator b and denominator a.  If a is not specified, it defaults to
-## 1. If n is not specified, or specified as [], it will be chosen such
-## that the signal has a chance to die down to -120dB, or to not explode
-## beyond 120dB, or to show five periods if there is no significant
-## damping. If no return arguments are requested, plot the results.
+## Generate impulse-response characteristics of the filter.
 ##
-## @seealso{freqz, zplane}
+## The filter coefficients correspond to the z-plane rational function
+## with numerator b and denominator a.  If a is not specified, it
+## defaults to 1.  When @var{n} is a scalar, it specifies the number of
+## points to compute (default: determined by @code{impzlength}).  When
+## @var{n} is a vector of non-negative integers, the response is
+## computed only at those sample indices.  The sampling frequency
+## @var{fs} (default: 1) controls the time spacing in the output
+## @var{t}.  With no output arguments, the result is plotted.
+##
+## @seealso{freqz, zplane, stepz,impzlength}
 ## @end deftypefn
-
-## FIXME: Call equivalent function from control toolbox since it is
-##        probably more sophisticated than this one, and since it
-##        is silly to maintain two different versions of essentially
-##        the same thing.
 
 function [x_r, t_r] = impz(b, a = [1], n = [], fs = 1)
 
@@ -43,52 +42,48 @@ function [x_r, t_r] = impz(b, a = [1], n = [], fs = 1)
     print_usage;
   endif
 
-  if isempty(n) && length(a) > 1
-    precision = 1e-6;
-    r = roots(a);
-    maxpole = max(abs(r));
-    if (maxpole > 1+precision)     # unstable -- cutoff at 120 dB
-      n = floor(6/log10(maxpole));
-    elseif (maxpole < 1-precision) # stable -- cutoff at -120 dB
-      n = floor(-6/log10(maxpole));
-    else                           # periodic -- cutoff after 5 cycles
-      n = 30;
-
-      ## find longest period less than infinity
-      ## cutoff after 5 cycles (w=10*pi)
-      rperiodic = r(find(abs(r)>=1-precision & abs(arg(r))>0));
-      if !isempty(rperiodic)
-        n_periodic = ceil(10*pi./min(abs(arg(rperiodic))));
-        if (n_periodic > n)
-          n = n_periodic;
-        endif
-      endif
-
-      ## find most damped pole
-      ## cutoff at -60 dB
-      rdamped = r(find(abs(r)<1-precision));
-      if !isempty(rdamped)
-        n_damped = floor(-3/log10(max(abs(rdamped))));
-        if (n_damped > n)
-          n = n_damped;
-        endif
-      endif
+  ## Determine n (number of points or vector of indices)
+  n_is_vector = false;
+  if isempty (n)
+    ## Auto-compute length using impzlength
+    if nargin >= 2 && !isscalar (a)
+      n = impzlength (b, a);
+    else
+      n = impzlength (b);
     endif
-    n = n + length(b);
-  elseif isempty(n)
-    n = length(b);
-  elseif (! isscalar (n))
-    ## TODO: missing option of having N as a vector of values to
-    ##       compute the impulse response.
-    error ("impz: N must be empty or a scalar");
+  elseif isscalar (n)
+  ## n is a giving number for points
+    if n < 0 || n != fix (n)
+      error ("impz: N must be a non-negative integer when specified as a scalar as points");
+    endif
+  else
+    ## n is a vector of non-negative integer indices
+    n = n(:);
+    if any (n < 0) || any (n != fix (n))
+      error ("impz: N must contain non-negative integers when specified as a vector");
+    endif
+    n_is_vector = true;
   endif
 
-  if length(a) == 1
-    x = fftfilt(b/a, [1, zeros(1,n-1)]');
+  ## Compute impulse response
+  if n_is_vector
+    max_n = max (n);
+    if length (a) == 1
+      x_full = fftfilt (b / a, [1; zeros(max_n, 1)]);
+    else
+      x_full = filter (b, a, [1; zeros(max_n, 1)]);
+    endif
+    ## Extract the impulse response at the specified indices
+    x = x_full(n + 1);
+    t = n / fs;
   else
-    x = filter(b, a, [1, zeros(1,n-1)]');
+    if length (a) == 1
+      x = fftfilt (b / a, [1; zeros(n-1, 1)]);
+    else
+      x = filter (b, a, [1; zeros(n-1, 1)]);
+    endif
+    t = (0:n-1).' / fs;
   endif
-  t = [0:n-1]/fs;
 
   if nargout >= 1 x_r = x; endif
   if nargout >= 2 t_r = t; endif
@@ -102,7 +97,7 @@ function [x_r, t_r] = impz(b, a = [1], n = [], fs = 1)
         label_text = "Time (sec)";
       endif
     else
-      label_text = "samples";
+      label_text = "n (samples)";
     endif
 
     stem(t, x);
@@ -113,10 +108,84 @@ function [x_r, t_r] = impz(b, a = [1], n = [], fs = 1)
 
 endfunction
 
+%!demo
+%! ## Impulse response of a 4th-order lowpass Butterworth IIR filter
+%! [b, a] = butter (4, 0.2);
+%! impz (b, a);
+
+%!demo
+%! ## Impulse response with a custom number of points
+%! impz (1, [1, -0.9], 30);
+
+%!demo
+%! ## Impulse response at specific sample indices
+%! impz (1, [1, -0.9], [0 5 10 15 20]);
+
+%!demo
+%! ## Impulse response with sampling frequency (time axis in seconds)
+%! [b, a] = butter (4, 0.2);
+%! impz (b, a, [], 1000);
+
+%!demo
+%! ## Impulse response at specific time points with sampling frequency
+%! [b, a] = butter (4, 0.2);
+%! impz (b, a, 0:5:50, 1000);
+
 %!assert (size (impz (1, [1 -1 0.9], 100)), [100 1])
 
-## Missing functionality
-%!xtest
+%!test
 %! [h, t] = impz (1, [1 -1 0.9], 0:101);
-%! assert (size (h), [101 1])
-%! assert (t, 0:101)
+%! assert (size (h), [102 1]);
+%! assert (t, (0:101)');
+
+%!test
+%! ## FIR filter with scalar n
+%! [h, t] = impz (1, [1,-0.5], 5);
+%! assert (h, [1.0000; 0.5000; 0.2500; 0.1250; 0.0625]);
+%! assert (t, (0:4)');
+
+%!test
+%! ## FIR filter with vector n
+%! [h, t] = impz (1, [1,-0.5], [0 2 4],2);
+%! assert (h, [1.0000; 0.2500; 0.0625]);
+%! assert (t, [0; 2; 4]/2);
+
+%!test
+%! ## With fs provided
+%! [h, t] = impz (1, [1 -1 0.9], 10, 1000);
+%! assert (size (h), [10, 1]);
+%! assert (size (t), [10, 1]);
+%! assert (t(2) - t(1), 0.001);
+
+## old code for determining n based on poles of the filter
+##
+## if isempty(n) && length(a) > 1
+##     precision = 1e-6;
+##     r = roots(a);
+##     maxpole = max(abs(r));
+##     if (maxpole > 1+precision)     # unstable -- cutoff at 120 dB
+##       n = floor(6/log10(maxpole));
+##     elseif (maxpole < 1-precision) # stable -- cutoff at -120 dB
+##       n = floor(-6/log10(maxpole));
+##     else                           # periodic -- cutoff after 5 cycles
+##       n = 30;
+## 
+##       ## find longest period less than infinity
+##       ## cutoff after 5 cycles (w=10*pi)
+##       rperiodic = r(find(abs(r)>=1-precision & abs(arg(r))>0));
+##       if !isempty(rperiodic)
+##         n_periodic = ceil(10*pi./min(abs(arg(rperiodic))));
+##         if (n_periodic > n)
+##           n = n_periodic;
+##         endif
+##       endif
+## 
+##       ## find most damped pole
+##       ## cutoff at -60 dB
+##       rdamped = r(find(abs(r)<1-precision));
+##       if !isempty(rdamped)
+##         n_damped = floor(-3/log10(max(abs(rdamped))));
+##         if (n_damped > n)
+##           n = n_damped;
+##         endif
+##       endif

--- a/inst/impzlength.m
+++ b/inst/impzlength.m
@@ -1,0 +1,259 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {@var{len} =} impzlength (@var{b})
+## @deftypefnx {Function File} {@var{len} =} impzlength (@var{b}, @var{a})
+## @deftypefnx {Function File} {@var{len} =} impzlength (@var{sos})
+## @deftypefnx {Function File} {@var{len} =} impzlength (@dots{}, @var{tol})
+## Return the impulse response length of the specified filter.
+##
+## For a finite impulse response (FIR) filter specified by the numerator
+## coefficients @var{b}, the length is simply the number of coefficients
+## in @var{b}.
+##
+## For an infinite impulse response (IIR) filter specified by the numerator
+## @var{b} and denominator @var{a} polynomials in z^-1, the function
+## computes an effective impulse response sequence length.
+##
+## The filter can also be specified by a @var{K}-by-6 second-order sections
+## matrix @var{sos}, where @var{K} is the number of sections.  In this case,
+## the matrix is converted to transfer function form @var{b} and @var{a}
+## before computing the length.
+##
+## The algorithm proceeds as follows:
+##
+## @enumerate
+## @item
+## If the filter is FIR, the length is simply length (@var{b}).
+##
+## @item
+## The poles of the transfer function are computed as the roots of the
+## denominator polynomial @var{a}.
+##
+## @item
+## The multiplicity of the dominant pole (the pole with the largest
+## magnitude) is determined by counting poles at the same complex
+## coordinate within tolerance.
+##
+## @item
+## For a stable IIR filter (dominant pole magnitude @math{< 1 - 10^{-5}}),
+## the effective length is estimated as
+##
+## @code{floor (M * log10 (tol) / log10 (maxpole)) + delay}
+##
+## where @math{M} is the multiplicity of the dominant pole and @math{d}
+## is the initial delay (number of leading zeros in @var{b}).
+##
+## @item
+## For an unstable IIR filter (dominant pole magnitude @math{> 1 + 10^{-4}}),
+## a heuristic formula is used:
+##
+## @code{floor (6 / log10 (maxpole))}
+##
+## @item
+## For filters with poles near the unit circle (oscillatory behavior), the
+## length is the maximum of: five periods of the slowest oscillation,
+## and the decay length of damped poles, plus the initial delay.
+##
+## @end enumerate
+##
+## The optional argument @var{tol} specifies the tolerance used to
+## estimate the effective length of an IIR filter's impulse response.
+## The default tolerance is 5e-5.  Increasing @var{tol} estimates a
+## shorter effective length, while decreasing @var{tol} produces a longer
+## effective length.
+##
+## The returned value @var{len} is the effective impulse response length
+## of the specified filter.  This function is used by @code{impz} and
+## @code{stepz} to determine the number of points to plot.
+##
+## @seealso{impz, stepz}
+## @end deftypefn
+
+function len = impzlength (b, a, tol)
+
+  if (nargin < 1 || nargin > 3)
+    print_usage ();
+  endif
+
+  if (nargin < 3)
+    tol = 5e-5;
+  endif
+
+  ## Check if first input is a second-order sections matrix (K-by-6, K >= 2)
+  if (ismatrix (b) && size (b, 2) == 6 && size (b, 1) >= 2)
+    ## impzlength (sos) or impzlength (sos, tol)
+    if (nargin >= 2 && isscalar (a))
+      tol = a;
+    endif
+    [b, a] = sos2tf (b);
+  elseif (nargin == 1)
+    ## impzlength (b) — FIR filter, use a = 1
+    a = 1;
+  endif
+
+  if (isscalar (a) || isempty (a))
+    ## FIR filter: length equals number of numerator coefficients
+    len = length (b);
+    return;
+  endif
+
+  ## [0, 0, ..., 0, b_delay, ...] find delay index of first non-zero coefficient in b
+  idx = find (b, 1, 'first');
+  if isempty (idx)
+    b_delay = 0;
+  else
+    b_delay = idx - 1;
+  end
+
+  ## Find poles of the transfer function
+  r = roots (a);
+  abs_r = abs (r);
+  maxpole = max (abs_r);
+
+  ## Find multiplicity of the dominant pole (true repeated roots).
+  ## Count poles at the same complex coordinate, NOT just same magnitude,
+  ## to avoid counting complex conjugate pairs as repeated.
+  idx_maxmag = abs (abs_r - maxpole) < tol;
+  candidates = r(idx_maxmag);
+  if (!isempty (candidates))
+    ref = candidates(1);
+    mult = sum (abs (r - ref) < tol);
+  else
+    mult = 1; 
+  endif
+
+  if (maxpole > 1 + 1e-4)
+    ## Unstable IIR filter
+    len = floor (6 / log10 (maxpole));
+
+  elseif (maxpole < 1 - 1e-5)
+    ## Stable IIR filter
+    len = floor (mult * log10 (tol) / log10 (maxpole))+ b_delay;
+
+  else
+    ## Filter has poles near the unit circle (oscillatory).
+    ## Compute five periods of the slowest oscillation.
+    n_periodic = 10;
+    for i = 1:length (r)
+      if abs(r(i)-1)<1e-5
+        r(i) = -r(i);  ## avoid numerical issues with arg(r) near 0
+      endif
+    endfor
+    rperiodic = r(abs_r >= 1 - 1e-5 & abs_r <= 1 + 1e-4 & abs (arg (r)) > 0);
+    if (!isempty (rperiodic))
+      n_periodic = floor (5 * 2 * pi / min (abs (arg (rperiodic))));
+    endif
+
+    ## Compute damped component length
+    n_damped = 0;
+    rdamped = r(abs_r < 1 - 1e-5);
+    if (!isempty (rdamped))
+      max_rdamped = max (abs (rdamped));
+
+      ## Find true repeated roots among damped poles (same complex coordinate)
+      idx_damped_max = abs (abs (rdamped) - max_rdamped) < tol;
+      candidates_damped = rdamped(idx_damped_max);
+
+      if (!isempty (candidates_damped))
+        ref_damped = candidates_damped(1);
+        mult_damped = sum (abs (rdamped - ref_damped) < tol);
+      else
+        mult_damped = 1;
+      endif
+
+      n_damped = floor (mult_damped * log10 (tol) / log10 (max_rdamped));
+    endif
+
+    len = max (n_periodic, n_damped) + b_delay;
+  endif
+
+endfunction
+
+## test below shows different pole cases
+%!test
+%! ## FIR filter
+%! assert (impzlength ([1 2 3 4 5]), 5);
+
+%!test
+%! ## Stable IIR filter and with different tolerance
+%! b = 1;
+%! a = [1 -0.95];
+%! len1 = impzlength (b, a);
+%! len2 = impzlength (b, a, 1e-3);
+%! len3 = impzlength (b, a, 1e-7);
+%! assert (len1, 193);
+%! assert (len2, 134);
+%! assert (len3, 314);
+
+%!test
+%! ## Unstable IIR filter
+%! b = 1;
+%! a = [1 -1.1];
+%! len = impzlength (b, a);
+%! assert (len, 144);
+
+%!test
+%! ## Oscillatory IIR filter
+%! b = 1;
+%! a = [1 0.5 1];
+%! len = impzlength (b, a);
+%! assert (len, 17);
+
+%!test
+%! ## IIR filter with repeated poles
+%! b = 1;
+%! a = conv([1 -0.9], [1 -0.9]);
+%! len = impzlength(b, a);
+%! assert (len, 187);
+
+%!test
+%! ## Oscillatory IIR filter with damped component
+%! b = 1;
+%! a1 = [1, 0.5, 1];  ## oscillatory,len = 17
+%! a2 = [1, -0.1];    ## damped,len=4
+%! a3 = [1, -0.9];    ## damped,len=93
+%! len1 = impzlength(b, conv(a1, a2));  ## damped component shorter than oscillatory
+%! len2 = impzlength(b, conv(a1, a3));  ## damped component longer than oscillatory
+%! assert (len1, 17);
+%! assert (len2, 93);
+
+%!test
+%! ## IIR filter with delay
+%! b = [0 0 1]; 
+%! a = [1 -0.95];
+%! len = impzlength(b, a);
+%! assert (len, 195);  ## 193 + 2 delay
+
+%!test
+%! ## Special case: this is why r(i) = -r(i) to avoid case with arg(r) near 0
+%! b = 1;
+%! a = [1, -1];
+%! len=impzlength(b,a);
+%! assert(len,10);
+
+%!test
+%! ## Second-order sections input
+%! [z, p, k] = ellip (4, 1, 60, 0.4);
+%! sos = zp2sos (z, p, k);
+%! len = impzlength (sos);
+%! assert (len, 80);
+
+%!test
+%! ## Input validation
+%!error impzlength ();
+%!error impzlength (1, 2, 3, 4);

--- a/inst/stepz.m
+++ b/inst/stepz.m
@@ -1,0 +1,156 @@
+## Copyright (C) 2026 Tang Chonghao <chadholton@qq.com>
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; see the file COPYING. If not, see
+## <https://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn  {Function File} {[@var{x}, @var{t}] =} stepz (@var{b})
+## @deftypefnx {Function File} {[@var{x}, @var{t}] =} stepz (@var{b}, @var{a})
+## @deftypefnx {Function File} {[@var{x}, @var{t}] =} stepz (@var{b}, @var{a}, @var{n})
+## @deftypefnx {Function File} {[@var{x}, @var{t}] =} stepz (@var{b}, @var{a}, @var{n}, @var{fs})
+## @deftypefnx {Function File} {} stepz (@dots{})
+##
+## Generate step-response characteristics of the filter.
+##
+## The filter coefficients correspond to the z-plane rational function
+## with numerator b and denominator a.  If a is not specified, it
+## defaults to 1.  When @var{n} is a scalar, it specifies the number of
+## points to compute (default: determined by @code{impzlength}).  When
+## @var{n} is a vector of non-negative integers, the response is
+## computed only at those sample indices.  The sampling frequency
+## @var{fs} (default: 1) controls the time spacing in the output
+## @var{t}.  With no output arguments, the result is plotted.
+##
+## @seealso{freqz, zplane, impz, impzlength}
+## @end deftypefn
+
+function [x_r, t_r] = stepz(b, a = [1], n = [], fs = 1)
+
+  if nargin == 0 || nargin > 4
+    print_usage;
+  endif
+
+  ## Determine n (number of points or vector of indices)
+  n_is_vector = false;
+  if isempty (n)
+    ## Auto-compute length using impzlength
+    if nargin >= 2 && !isscalar (a)
+      n = impzlength (b, a);
+    else
+      n = impzlength (b);
+    endif
+  elseif isscalar (n)
+    if n < 0 || n != fix (n)
+      error ("stepz: N must be a non-negative integer when specified as a scalar as points");
+    endif
+  else
+    ## n is a vector of non-negative integer indices
+    n = n(:);
+    if any (n < 0) || any (n != fix (n))
+      error ("stepz: N must contain non-negative integers when specified as a vector");
+    endif
+    n_is_vector = true;
+  endif
+
+  ## Compute step response
+  if n_is_vector
+    max_n = max (n);
+    if length (a) == 1
+      x_full = fftfilt (b / a, ones (max_n + 1, 1));
+    else
+      x_full = filter (b, a, ones (max_n + 1, 1));
+    endif
+    ## Extract the step response at the specified indices
+    x = x_full(n + 1);
+    t = n / fs;
+  else
+    if length (a) == 1
+      x = fftfilt (b / a, ones (n, 1));
+    else
+      x = filter (b, a, ones (n, 1));
+    endif
+    t = (0:n-1).' / fs;
+  endif
+
+  if nargout >= 1 x_r = x; endif
+  if nargout >= 2 t_r = t; endif
+  if nargout == 0
+    # scale and work out xlabel
+    if nargin == 4
+      if max(t) < 1
+        label_text = "Time (msec)";
+        t = t * 1000;
+      else
+        label_text = "Time (sec)";
+      endif
+    else
+      label_text = "n (samples)";
+    endif
+
+    stem(t, x);
+    title("Step Response");
+    xlabel(label_text);
+    ylabel("Amplitude");
+  endif
+
+endfunction
+
+%!demo
+%! ## Step response of a 4th-order lowpass Butterworth IIR filter
+%! [b, a] = butter (4, 0.2);
+%! stepz (b, a);
+
+%!demo
+%! ## Step response with a custom number of points
+%! stepz (1, [1, -0.9], 30);
+
+%!demo
+%! ## Step response at specific sample indices
+%! stepz (1, [1, -0.9], [0 5 10 15 20]);
+
+%!demo
+%! ## Step response with sampling frequency (time axis in seconds)
+%! [b, a] = butter (4, 0.2);
+%! stepz (b, a, [], 1000);
+
+%!demo
+%! ## Step response at specific time points with sampling frequency
+%! [b, a] = butter (4, 0.2);
+%! stepz (b, a, 0:5:50, 1000);
+
+%!assert (size (stepz (1, [1 -1 0.9], 100)), [100 1])
+
+%!test
+%! [h, t] = stepz (1, [1 -1 0.9], 0:101);
+%! assert (size (h), [102 1]);
+%! assert (t, (0:101)');
+
+%!test
+%! ## FIR filter with scalar n
+%! [h, t] = stepz (1, [1,-0.5], 5);
+%! assert (h, [1.0000; 1.5000; 1.7500; 1.8750; 1.9375]);
+%! assert (t, (0:4)');
+
+%!test
+%! ## FIR filter with vector n
+%! [h, t] = stepz (1, [1,-0.5], [0 2 4], 2);
+%! assert (h, [1.0000; 1.7500; 1.9375]);
+%! assert (t, [0; 2; 4]/2);
+
+%!test
+%! ## With fs provided
+%! [h, t] = stepz (1, [1 -1 0.9], 10, 1000);
+%! assert (size (h), [10, 1]);
+%! assert (size (t), [10, 1]);
+%! assert (t(2) - t(1), 0.001);


### PR DESCRIPTION
Introduce `impzlength`: a new function that estimates the effective impulse-response length for FIR, IIR and SOS filters (supports optional tolerance). The examples provided in the test section represent the types I have taken into consideration. 

This function is used by `impz` and `stepz`. The modifications to `impz` and the implementation of `stepz` are still in progress.