### PR TITLE
Extend freqs

### DIFF
--- a/inst/freqs.m
+++ b/inst/freqs.m
@@ -98,6 +98,25 @@ endfunction
 %! A = [1 3 2];
 %! freqs (B, A);
 
+%!test
+%! ## Test frequency response of H(s) = 1/(s+1) at known frequencies
+%! B = [1];
+%! A = [1 1];
+%! w = logspace (-1, 1, 10);
+%! H = freqs (B, A, w);
+%! ## H(jw) = 1/(jw+1)
+%! H_expected = 1 ./ (1 + 1j * w);
+%! assert (H, H_expected, 1e-10);
+
+%!test
+%! ## Test with two outputs (H and Wout)
+%! B = [1 0];
+%! A = [1 2 1];
+%! w = logspace (-1, 2, 100);
+%! [H, Wout] = freqs (B, A, w);
+%! assert (H, polyval (B, 1j * w) ./ polyval (A, 1j * w), 1e-10);
+%! assert (Wout, w);
+
 %!error <positive integer> freqs ([1], [1 1], 2.5)
 %!error <positive integer> freqs ([1], [1 1], -1)
 %!error freqs ([1])

--- a/inst/freqs.m
+++ b/inst/freqs.m
@@ -16,11 +16,16 @@
 
 ## -*- texinfo -*-
 ## @deftypefn  {Function File} {@var{h} =} freqs (@var{b}, @var{a}, @var{w})
-## @deftypefnx {Function File} {} freqs (@var{b}, @var{a}, @var{w})
+## @deftypefnx {Function File} {[@var{h}, @var{wout}] =} freqs (@var{b}, @var{a}, @var{n})
+## @deftypefnx {Function File} {} freqs (@dots{})
+## Compute the s-plane frequency response of the analog filter B(s)/A(s).
 ##
-## Compute the s-plane frequency response of the IIR filter B(s)/A(s) as
-## H = polyval(B,j*W)./polyval(A,j*W).  If called with no output
-## argument, a plot of magnitude and phase are displayed.
+## The frequency response is evaluated at the angular frequencies specified
+## by vector @var{w} (in rad/s).  If the third argument is a scalar integer
+## @var{n}, or if it is omitted, the frequency response is computed at
+## @var{n} logarithmically spaced frequencies (default @var{n} = 200).
+##
+## If no output argument is requested, the magnitude and phase are plotted.
 ##
 ## Example:
 ## @example
@@ -30,16 +35,54 @@
 ## @end example
 ## @end deftypefn
 
-function H = freqs(B,A,W)
+function [H, Wout] = freqs(B, A, W)
 
-  if (nargin ~= 3 || nargout>1)
-    print_usage;
+  if (nargin < 2 || nargin > 3)
+    print_usage ();
   endif
 
-  H = polyval(B,j*W)./polyval(A,j*W);
+  have_w = false;
 
-  if nargout<1
-    freqs_plot(W,H);
+  if (nargin == 2)
+    ## freqs (b, a)
+    n = 200;
+  else
+    ## nargin == 3
+    if (isscalar (W))
+      ## freqs (b, a, n)
+      if (! isreal (W) || W < 1 || W != fix (W))
+        error ("freqs: W must be a positive integer");
+      endif
+      n = W;
+    else
+      ## freqs (b, a, w)
+      have_w = true;
+    endif
+  endif
+
+  if (have_w)
+    H = polyval (B, 1j * W) ./ polyval (A, 1j * W);
+    Wout = W;
+  else
+    ## Generate a logarithmically spaced frequency vector.
+    ## Determine the frequency range from the filter poles.
+    poles = roots (A);
+    poles = poles(poles != 0);
+    if (isempty (poles))
+      wmin = 1e-3;
+      wmax = 1e3;
+    else
+      pole_mags = abs (poles);
+      wmin = min (pole_mags) * 0.1;
+      wmax = max (pole_mags) * 10;
+    endif
+    ## FIXME: MATLAB's freqs uses a more sophisticated method to determine the frequency range.
+    Wout = logspace (log10 (wmin), log10 (wmax), n).';
+    H = polyval (B, 1j * Wout) ./ polyval (A, 1j * Wout);
+  endif
+
+  if (nargout == 0)
+    freqs_plot (Wout, H);
   endif
 
 endfunction
@@ -47,5 +90,15 @@ endfunction
 %!demo
 %! B = [1 2];
 %! A = [1 1];
-%! w = linspace(0,4,128);
-%! freqs(B,A,w);
+%! w = logspace (-2, 1, 128);
+%! freqs (B, A, w);
+
+%!demo
+%! B = [0.5 0.3 1];
+%! A = [1 3 2];
+%! freqs (B, A);
+
+%!error <positive integer> freqs ([1], [1 1], 2.5)
+%!error <positive integer> freqs ([1], [1 1], -1)
+%!error freqs ([1])
+%!error freqs ([1], [1 1], [1 2], 3)

--- a/inst/freqs_plot.m
+++ b/inst/freqs_plot.m
@@ -15,38 +15,79 @@
 ## <https://www.gnu.org/licenses/>.
 
 ## -*- texinfo -*-
-## @deftypefn {Function File} {} freqs_plot (@var{w}, @var{h})
+## @deftypefn  {Function File} {} freqs_plot (@var{w}, @var{h})
+## @deftypefnx {Function File} {} freqs_plot (@var{w}, @var{h}, @var{freqscale})
 ## Plot the amplitude and phase of the vector @var{h}.
+##
+## The optional argument @var{freqscale} specifies the scaling of the
+## frequency axis.  It can be @qcode{"log"} (default) or @qcode{"linear"}.
+## @seealso{freqs}
 ## @end deftypefn
 
-function freqs_plot(w,h)
+function freqs_plot(w, h, freqscale)
+
+  if (nargin < 2 || nargin > 3)
+    print_usage ();
+  endif
+
+  if (nargin < 3)
+    freqscale = "log";
+  endif
 
   n = length(w);
   mag = 20*log10(abs(h));
   phase = unwrap(arg(h));
   maxmag = max(mag);
 
-  subplot(211);
-  plot(w, mag, ";Magnitude (dB);");
-  title('Frequency response plot by freqs');
-  axis("labely");
-  ylabel("dB");
-  xlabel("");
-  grid("on");
-  if (maxmag - min(mag) > 100) # make 100 a parameter?
-    axis([w(1), w(n), maxmag-100, maxmag]);
-  else
-    axis("autoy");
-  endif
+  switch (freqscale)
+    case "log"
+      ## Kick out zero frequencies (can't plot on log scale)
+      idx = (w > 0);
+      w = w(idx);
+      mag = mag(idx);
+      phase = phase(idx);
 
-  subplot(212);
-  plot(w, phase/(2*pi), ";Phase (radians/2pi);");
-  axis("label");
-  title("");
-  grid("on");
-  axis("autoy");
-  xlabel("Frequency (rad/sec)");
-  ylabel("Cycles");
-  axis([w(1), w(n)]);
+      subplot(211);
+      semilogx(w, mag);
+      xlim([w(1), w(end)]);
+      grid("on");
+      ylabel("Magnitude (dB)");
+      title("Frequency Response");
+
+      subplot(212);
+      semilogx(w, phase*180/pi);
+      xlim([w(1), w(end)]);
+      grid("on");
+      xlabel("Frequency (rad/s)");
+      ylabel("Phase (degrees)");
+
+    case "linear"
+      ## Original style with linear frequency axis
+      subplot(211);
+      plot(w, mag, ";Magnitude (dB);");
+      title('Frequency response plot by freqs');
+      axis("labely");
+      ylabel("dB");
+      xlabel("");
+      grid("on");
+      if (maxmag - min(mag) > 100) # make 100 a parameter?
+        axis([w(1), w(n), maxmag-100, maxmag]);
+      else
+        axis("autoy");
+      endif
+
+      subplot(212);
+      plot(w, phase/(2*pi), ";Phase (radians/2pi);");
+      axis("label");
+      title("");
+      grid("on");
+      axis("autoy");
+      xlabel("Frequency (rad/sec)");
+      ylabel("Cycles");
+      axis([w(1), w(n)]);
+
+    otherwise
+      error('freqs_plot: FREQSCALE must be "log" or "linear"');
+  endswitch
 
 endfunction

--- a/inst/freqs_plot.m
+++ b/inst/freqs_plot.m
@@ -91,3 +91,17 @@ function freqs_plot(w, h, freqscale)
   endswitch
 
 endfunction
+
+%!demo
+%! B = [1];
+%! A = [1, sqrt(2), 1];
+%! w = logspace (-2, 2, 200);
+%! H = freqs (B, A, w);
+%! freqs_plot (w, H);
+
+%!demo
+%! B = [1];
+%! A = [1, 0.2, 1];
+%! w = linspace (0, 3, 200);
+%! H = freqs (B, A, w);
+%! freqs_plot (w, H, "linear");


### PR DESCRIPTION
I have added the calling syntax `[h,wout] = freqs(b,a,n)`, and made `freqs_plot` use logarithmic plotting. 
Before the modification, there was only `h = freqs(b,a,w)`, whose function is to compute the frequency response `h` at the specified frequencies `w`. The new addition, `[h,wout] = freqs(b,a,n)`, first computes the frequency points `w` based on the number of points `n`, and then computes `h` at those frequencies. Meanwhile, `n` has a default value of 200, which enables the calling form `freqs(b,a)`. This brings it closer to the MATLAB behavior.

My guess is that the previous developer didn't add `[h,wout] = freqs(b,a,n)` because MATLAB's `freqs` uses a more sophisticated method to determine the frequency range. I didn't fully replicate it either, and instead simply used `logspace`.